### PR TITLE
feat: prompt for an account when several are configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@
 # ---------------------------------------------------------------------------
 # CLI accounts live under:
 #   ~/.config/weread/accounts/<alias>/
-# `weread login` creates an account on the built-in `eink` client with a QR login.
-# `weread --account <name> login --client <id>` selects another loaded provider.
+# `weread-omni login` creates an account on the built-in `eink` client with a QR login.
+# `weread-omni --account <name> login --client <id>` selects another loaded provider.
 #
 # Semicolon-separated ESM package names, file: URLs, or absolute paths. Each
 # module must default-export a client plugin descriptor compatible with plugin
@@ -28,7 +28,7 @@
 # WEREAD_CONFIG_DIR=/path/to/config-dir          # [optional]
 
 # Account used when no --account is given, overriding the default recorded by
-# `weread accounts use <alias>`. Ignored when it names no configured account.
+# `weread-omni accounts use <alias>`. Ignored when it names no configured account.
 # WEREAD_ACCOUNT=work                            # [optional]
 
 # Where downloaded content is kept so it is never fetched twice. Deliberately
@@ -39,7 +39,7 @@
 
 # Use the content library even where the filesystem cannot support SQLite's
 # write-ahead logging, which usually means a network share. Off by default:
-# without it two `weread` processes can corrupt the database rather than take
+# without it two `weread-omni` processes can corrupt the database rather than take
 # turns. Set it only when you are certain nothing else writes there.
 # WEREAD_LIBRARY_ALLOW_UNSAFE=1                  # [optional]
 
@@ -50,7 +50,7 @@
 # constructor arg -> selected credential file -> environment variables. The
 # environment is bootstrap input only while the file does not exist. Providing
 # only one or two required values is an error; either set all three or set none
-# and use `weread login` instead. Keep deviceId with its refreshToken.
+# and use `weread-omni login` instead. Keep deviceId with its refreshToken.
 # The access token is an optional cache. After bootstrap, the credential file
 # takes precedence; the default direct-client file is credentials.eink.json.
 # WEREAD_VID=your-account-vid                   # [required for env bootstrap] numeric account id
@@ -65,7 +65,7 @@
 # moves to the next (Happy Eyeballs). Node's own default is 250 ms, and a real
 # connect to WeRead takes ~255 ms from Europe or the Americas — so Node kills the
 # attempt that was about to succeed and `fetch` reports a bare `network error`,
-# intermittently. The `weread` binary therefore raises it to 1000 ms; the SDK
+# intermittently. The `weread-omni` binary therefore raises it to 1000 ms; the SDK
 # never touches this process-wide default. Applies to the binary only, and only
 # at startup. Unset or empty means the default below. Set 0 to keep Node's own 250 ms;
 # so does any other value that is not a positive integer of milliseconds within

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             .trim().split(/\r?\n/).at(-1);
           run("npm", ["install", "--global", "--engine-strict", "--no-audit", "--no-fund", resolve(tarball)],
             { stdio: "inherit" });
-          run("weread", ["--help"], { stdio: "inherit" });
+          run("weread-omni", ["--help"], { stdio: "inherit" });
 
   pack-smoke:
     # Packs the real tarball, installs it into a throwaway prefix, imports all three
@@ -123,4 +123,4 @@ jobs:
           npm install --engine-strict --ignore-scripts --no-audit --no-fund "${tarballs[0]}"
           node --input-type=module --eval \
             'await Promise.all(["weread-omni", "weread-omni/cli"].map((name) => import(name)))'
-          ./node_modules/.bin/weread --help >/dev/null
+          ./node_modules/.bin/weread-omni --help >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     # `workflow_dispatch` is available to anyone with write access, so the workflow's own
-    # input validation is not an authorization boundary. Configure required reviewers on the
-    # `npm-publish` environment in repository settings and hold NPM_TOKEN there: a dispatch
-    # then blocks pending approval instead of publishing.
+    # input validation is not an authorization boundary. Required reviewers on the
+    # `npm-publish` environment are: a dispatch blocks pending approval instead of
+    # publishing. The environment is also half of the trust relationship npm checks, so
+    # a job that skipped it could not obtain a credential at all.
     environment: npm-publish
     env:
       RELEASE_TAG: ${{ inputs.tag }}
@@ -188,20 +189,15 @@ jobs:
           node --version
           npm --version
 
-      # The registry credential is scoped to the two steps below that talk to the
-      # registry; no other step in this job can read it. It must be a granular or
-      # automation token (or OIDC trusted publishing) — a legacy token cannot produce
-      # a provenance attestation.
-      - name: Confirm registry authentication
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      # Authentication is OIDC trusted publishing: npm exchanges this job's `id-token`
+      # for a short-lived registry credential scoped to this package, this repository,
+      # this workflow file, and the npm-publish environment. There is deliberately no
+      # token fallback -- a misconfigured trust relationship must fail the publish, not
+      # quietly reach for a long-lived credential.
+      #
       # Rechecks and immediately publishes the retained file. Never the working directory.
       - name: Recheck the digest and publish the retained tarball
         run: |
           set -euo pipefail
           test "$(sha512sum "$TARBALL" | cut -d ' ' -f1)" = "$(jq -r .sha512 candidate/candidate-metadata.json)"
           npm publish "$TARBALL" --provenance --access public --tag "$NPM_DIST_TAG"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ CLI surface is **experimental** and may change in a minor release.
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Changed
+
+- **The CLI command is now `weread-omni`.** The official WeRead Agent Skill
+  installs a `weread` command, so shipping our own meant whichever package was
+  installed second silently won the name. Anyone who installed `0.1.0` should
+  reinstall; the old `weread` binary is not removed by upgrading.
+- Recovery hints name the new command, so a copied suggestion works as printed.
+
+Credential and library locations are untouched: `~/.config/weread/` and
+`~/.local/share/weread/library` keep an existing login and cached content. The
+projected tool names, the upstream host, and the bundled skill are unchanged.
+
 ## [0.1.0]
 
 First public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,13 @@ First public release.
   Chapter bodies are stored the same way, but only when the configured client
   serves them. The library is on by default; `--refresh` refetches and
   `--no-library` opts out per command.
-  `weread library path|status|verify` inspect it. Records live in SQLite under
+  `weread-omni library path|status|verify` inspect it. Records live in SQLite under
   `WEREAD_LIBRARY_DIR` (default `~/.local/share/weread/library`) and payloads in
   a content-addressed file store beside it. Failed article retrievals are not
   stored, and locked chapter previews read as misses so they can be refetched.
-- **CLI** (`weread`). Every SDK operation has human-readable and JSON output.
-  `weread doctor` validates the installed package and selected credentials;
-  `weread login` stores credentials at mode `0600`.
+- **CLI** (`weread-omni`). Every SDK operation has human-readable and JSON output.
+  `weread-omni doctor` validates the installed package and selected credentials;
+  `weread-omni login` stores credentials at mode `0600`.
 - **Agent skill.** The packaged skill under `skills/` drives the JSON CLI,
   checks login state, follows operation-specific pagination, and asks before
   writes.
@@ -52,13 +52,13 @@ First public release.
 - **Public-account feeds and archives.** Scoped search, subscriptions, article
   history, RSS, Atom, JSON Feed, and no-overwrite directory exports include
   completeness diagnostics and strict source-URL validation.
-  `publicAccounts.paidContent` (`weread public-accounts paid-content`) asks the
+  `publicAccounts.paidContent` (`weread-omni public-accounts paid-content`) asks the
   entitlement endpoint for protected article bodies. Feed and export use it for
   `payType` 2, follow upstream substitute URLs for unentitled accounts, and
   fall back to the public URL with a diagnostic when lookup fails.
 - **Write policy.** Every operation is permitted by default; setting
   `WEREAD_READONLY` to `1` closes every write at once. Reads are never gated.
-- **Book import.** `weread import book` uploads EPUB, PDF, MOBI, TXT, and AZW3
+- **Book import.** `weread-omni import book` uploads EPUB, PDF, MOBI, TXT, and AZW3
   files to the shelf, checking extension and size first.
   WeRead's upstream import protocol ultimately sends a completed import to
   Tencent COS; Tencent COS is not the upload service's configurable backend.
@@ -69,7 +69,7 @@ First public release.
   which sits behind `--experimental-sqlite` on earlier releases.
 - `WeReadClient` is the canonical client: all 40 operations run on the E-Ink
   backend, and a failed request never falls back to a second one.
-- `weread login` runs the E-Ink QR flow and creates an account on the built-in
+- `weread-omni login` runs the E-Ink QR flow and creates an account on the built-in
   `eink` client. Accounts are prepared with the CLI; there is no login tool.
 - `createEinkClient()` returns the same `MobileApiClient` the built-in client
   uses. Android, iOS, and browser-session implementations can be supplied as
@@ -122,5 +122,6 @@ First public release.
 - This is an unofficial client. It is not affiliated with, endorsed by, or
   supported by Tencent or WeRead. See the legal section of the README.
 
-[Unreleased]: https://github.com/teng-lin/weread-omni/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/teng-lin/weread-omni/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/teng-lin/weread-omni/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/teng-lin/weread-omni/releases/tag/v0.1.0

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 weread-omni is a full-coverage agent skill and unofficial SDK for WeRead. Sign in by QR code and you get 40 read-and-write operations, far beyond the 6 read-only capabilities the official Skill provides.
 
-Those 40 operations have one implementation behind three entry points: the `weread` CLI, where every command can emit JSON; a fully typed TypeScript SDK; and the agent skill bundled in this repo.
+Those 40 operations have one implementation behind three entry points: the `weread-omni` CLI, where every command can emit JSON; a fully typed TypeScript SDK; and the agent skill bundled in this repo.
 
 This project is not affiliated with, endorsed by, or supported by Tencent or WeRead.
 
@@ -28,33 +28,33 @@ You need Node.js `>=22.13.0` and a WeChat account with working WeRead access.
 
 ```bash
 npm install --global weread-omni
-weread login --json
-weread doctor --json
-weread search books "The Three-Body Problem" --json
+weread-omni login --json
+weread-omni doctor --json
+weread-omni search books "The Three-Body Problem" --json
 ```
 
-`weread login` presents a single E-Ink QR code — scan it once with your WeRead account.
+`weread-omni login` presents a single E-Ink QR code — scan it once with your WeRead account.
 
-QR codes and progress go to stderr. On success, the JSON written to stdout contains only the account alias, client ID, `vid`, and device ID—never tokens. `weread doctor` checks the active installation, authentication, and one read-only request.
+QR codes and progress go to stderr. On success, the JSON written to stdout contains only the account alias, client ID, `vid`, and device ID—never tokens. `weread-omni doctor` checks the active installation, authentication, and one read-only request.
 
 ### Accounts and credentials
 
 The first login without `--account` creates the `default` account. Name additional accounts explicitly:
 
 ```bash
-weread --account work login --json
-weread accounts --json
-weread accounts use work --json
-weread --account default shelf sync --json
+weread-omni --account work login --json
+weread-omni accounts --json
+weread-omni accounts use work --json
+weread-omni --account default shelf sync --json
 ```
 
-An alias must start with a lowercase letter or digit. The remaining characters may be lowercase letters, digits, `-`, or `_`, for a maximum length of 64. If a command omits `--account`, the only configured account is selected automatically. With multiple accounts, `WEREAD_ACCOUNT` takes precedence over the default saved by `weread accounts use <alias>`. If neither selects an account, the CLI asks you to be explicit.
+An alias must start with a lowercase letter or digit. The remaining characters may be lowercase letters, digits, `-`, or `_`, for a maximum length of 64. If a command omits `--account`, the only configured account is selected automatically. With multiple accounts, `WEREAD_ACCOUNT` takes precedence over the default saved by `weread-omni accounts use <alias>`. If neither selects an account, the CLI asks you to be explicit.
 
 Credentials live under `~/.config/weread/accounts/<alias>/` by default. Directories use mode `0700`, and files use `0600`. Set `WEREAD_CONFIG_DIR` to move the configuration root. Every `WEREAD_*` variable read by the project is documented in [`.env.example`](https://github.com/teng-lin/weread-omni/blob/v0.1.0/.env.example).
 
 ### Install the agent skill
 
-The bundled `weread` skill teaches an agent to check authentication, call the JSON CLI, follow the correct pagination cursor, and ask before writing. It does not install the `weread` command, so complete the Quickstart first.
+The bundled `weread` skill teaches an agent to check authentication, call the JSON CLI, follow the correct pagination cursor, and ask before writing. It does not install the `weread-omni` command, so complete the Quickstart first.
 
 Install it with the [skills CLI](https://github.com/vercel-labs/skills):
 
@@ -89,18 +89,18 @@ Unset, empty, and whitespace-only values leave writes open, and so does any unre
 
 ## Common commands
 
-Every command supports `--json`. Agents should always request JSON output. Run `weread <command> --help` for the authoritative options.
+Every command supports `--json`. Agents should always request JSON output. Run `weread-omni <command> --help` for the authoritative options.
 
 ### Search and read
 
 ```bash
-weread search books "The Three-Body Problem" --json
-weread book info BOOK_ID --json
-weread book chapters BOOK_ID --json
-weread notes bookmarks BOOK_ID --json
-weread read-data detail --mode annually --json
-weread discover similar BOOK_ID --json
-weread ai ask-book BOOK_ID "What is this book's central argument?" --json
+weread-omni search books "The Three-Body Problem" --json
+weread-omni book info BOOK_ID --json
+weread-omni book chapters BOOK_ID --json
+weread-omni notes bookmarks BOOK_ID --json
+weread-omni read-data detail --mode annually --json
+weread-omni discover similar BOOK_ID --json
+weread-omni ai ask-book BOOK_ID "What is this book's central argument?" --json
 ```
 
 `book chapters` returns the `chapterUid` used by later commands.
@@ -108,12 +108,12 @@ weread ai ask-book BOOK_ID "What is this book's central argument?" --json
 ### Shelf, highlights, and reviews
 
 ```bash
-weread shelf sync --count 50 --json
-weread shelf add BOOK_ID --json
-weread shelf mark-reading BOOK_ID --json
+weread-omni shelf sync --count 50 --json
+weread-omni shelf add BOOK_ID --json
+weread-omni shelf mark-reading BOOK_ID --json
 
-weread notes add-bookmark BOOK_ID CHAPTER_UID "1-20" "text to highlight" --json
-weread review add BOOK_ID "My thoughts after reading" --star 80 --json
+weread-omni notes add-bookmark BOOK_ID CHAPTER_UID "1-20" "text to highlight" --json
+weread-omni review add BOOK_ID "My thoughts after reading" --star 80 --json
 ```
 
 `shelf pin`, `set-private`, `mark-finished`, and `mark-reading` perform the positive action by default. Use `--no-top`, `--no-secret`, `--no-finished`, or `--no-reading` to reverse it. Review ratings must be one of `20`, `40`, `60`, `80`, or `100`.
@@ -123,13 +123,13 @@ weread review add BOOK_ID "My thoughts after reading" --star 80 --json
 Search first and verify the exact `MP_WXS_<digits>` ID before subscribing:
 
 ```bash
-weread search books "PUBLIC_ACCOUNT_NAME" --scope 2 --json
-weread public-accounts subscribe MP_WXS_1234567890 --json
-weread public-accounts articles MP_WXS_1234567890 --count 20 --json
+weread-omni search books "PUBLIC_ACCOUNT_NAME" --scope 2 --json
+weread-omni public-accounts subscribe MP_WXS_1234567890 --json
+weread-omni public-accounts articles MP_WXS_1234567890 --count 20 --json
 
-weread public-accounts feed MP_WXS_1234567890 --format json --out ./account.feed.json --limit 50 --json
-weread public-accounts feed subscriptions --format rss --out ./subscriptions.xml --limit 50 --json
-weread public-accounts export MP_WXS_1234567890 --out ./account-archive --limit 100 --json
+weread-omni public-accounts feed MP_WXS_1234567890 --format json --out ./account.feed.json --limit 50 --json
+weread-omni public-accounts feed subscriptions --format rss --out ./subscriptions.xml --limit 50 --json
+weread-omni public-accounts export MP_WXS_1234567890 --out ./account-archive --limit 100 --json
 ```
 
 Feeds and exports process 20 articles by default, with a maximum `--limit` of 100. They never overwrite an existing file or directory. Article bodies are fetched only from validated HTTPS `mp.weixin.qq.com/s` URLs. JavaScript challenges and CAPTCHAs are reported in diagnostics, not bypassed.
@@ -139,7 +139,7 @@ The protected-article endpoint is wired up, but the recorded live check returned
 ### Import a personal book
 
 ```bash
-weread import book ./my-book.epub --json
+weread-omni import book ./my-book.epub --json
 ```
 
 EPUB, PDF, MOBI, TXT, and AZW3 are supported. The default size limit is 200 MiB; override it with `WEREAD_MAX_UPLOAD_BYTES`.
@@ -149,9 +149,9 @@ EPUB, PDF, MOBI, TXT, and AZW3 are supported. The default size limit is 200 MiB;
 The CLI stores book metadata, tables of contents, and downloaded public-account articles locally by default. A later request for the same content uses the local copy.
 
 ```bash
-weread library path --json
-weread library status --json
-weread library verify --json
+weread-omni library path --json
+weread-omni library status --json
+weread-omni library verify --json
 ```
 
 | Option | Effect |
@@ -179,76 +179,76 @@ This is a command index. All commands accept the global options below; each subc
 
 | Command | Purpose |
 | --- | --- |
-| `weread login` | Log in or re-authenticate the selected account |
-| `weread accounts` | List accounts and client IDs |
-| `weread accounts use <alias>` | Save the account used when `--account` is omitted |
-| `weread whoami` | Show the selected account's redacted identity |
-| `weread doctor` | Check installation, authentication, and connectivity |
-| `weread library path` | Print the local-library path |
-| `weread library status` | Summarize stored content |
-| `weread library verify` | Check the database and stored payloads |
+| `weread-omni login` | Log in or re-authenticate the selected account |
+| `weread-omni accounts` | List accounts and client IDs |
+| `weread-omni accounts use <alias>` | Save the account used when `--account` is omitted |
+| `weread-omni whoami` | Show the selected account's redacted identity |
+| `weread-omni doctor` | Check installation, authentication, and connectivity |
+| `weread-omni library path` | Print the local-library path |
+| `weread-omni library status` | Summarize stored content |
+| `weread-omni library verify` | Check the database and stored payloads |
 
 ### Books and shelf
 
 | Command | Purpose |
 | --- | --- |
-| `weread search books <keyword> [--scope <n>] [--count <n>] [--max-idx <n>]` | Search the catalog; ebooks by default |
-| `weread search suggest <keyword> [--count <n>]` | Return search autocomplete candidates |
-| `weread book info <bookId>` | Get book metadata |
-| `weread book detail <bookId> [--count <n>]` | Get cover artwork and bounded author, publisher, rightsholder, and category catalogs |
-| `weread book chapters <bookId>` | List the table of contents |
-| `weread book progress <bookId>` | Get reading progress |
-| `weread shelf sync [--count <n>] [--offset <n>] [--full]` | Page through the compact shelf; `--full` returns the raw response |
-| `weread shelf add <bookId>` | Add a book to the shelf |
-| `weread shelf delete <bookId> [-y, --yes]` | Remove a book from the shelf |
-| `weread shelf pin <bookId> [--no-top]` | Pin or unpin a book |
-| `weread shelf set-private <bookId> [--no-secret]` | Make a book private or public |
-| `weread shelf mark-finished <bookId> [--no-finished]` | Mark a book finished or undo it |
-| `weread shelf mark-reading <bookId> [--no-reading]` | Mark a book as reading or undo it |
+| `weread-omni search books <keyword> [--scope <n>] [--count <n>] [--max-idx <n>]` | Search the catalog; ebooks by default |
+| `weread-omni search suggest <keyword> [--count <n>]` | Return search autocomplete candidates |
+| `weread-omni book info <bookId>` | Get book metadata |
+| `weread-omni book detail <bookId> [--count <n>]` | Get cover artwork and bounded author, publisher, rightsholder, and category catalogs |
+| `weread-omni book chapters <bookId>` | List the table of contents |
+| `weread-omni book progress <bookId>` | Get reading progress |
+| `weread-omni shelf sync [--count <n>] [--offset <n>] [--full]` | Page through the compact shelf; `--full` returns the raw response |
+| `weread-omni shelf add <bookId>` | Add a book to the shelf |
+| `weread-omni shelf delete <bookId> [-y, --yes]` | Remove a book from the shelf |
+| `weread-omni shelf pin <bookId> [--no-top]` | Pin or unpin a book |
+| `weread-omni shelf set-private <bookId> [--no-secret]` | Make a book private or public |
+| `weread-omni shelf mark-finished <bookId> [--no-finished]` | Mark a book finished or undo it |
+| `weread-omni shelf mark-reading <bookId> [--no-reading]` | Mark a book as reading or undo it |
 
 ### Public accounts
 
 | Command | Purpose |
 | --- | --- |
-| `weread public-accounts subscriptions [--count <n>] [--offset <n>]` | Page through subscribed public accounts |
-| `weread public-accounts articles <accountId> [--count <n>] [--synckey <n>] [--offset <n>]` | Page through articles; `--synckey` starts a delta refresh and conflicts with `--offset` |
-| `weread public-accounts resolve-article <docUrl>` | Resolve an article URL to its WeRead review ID |
-| `weread public-accounts paid-content <docUrl>` | Attempt to fetch an entitled protected article |
-| `weread public-accounts subscribe <accountId>` | Subscribe to a public account |
-| `weread public-accounts unsubscribe <accountId> [-y, --yes]` | Unsubscribe from a public account |
-| `weread public-accounts feed <accountId\|subscriptions> --format <rss\|atom\|json> --out <file> [--limit <n>]` | Create a feed file |
-| `weread public-accounts export <accountId> --out <directory> [--limit <n>]` | Create an article export directory |
+| `weread-omni public-accounts subscriptions [--count <n>] [--offset <n>]` | Page through subscribed public accounts |
+| `weread-omni public-accounts articles <accountId> [--count <n>] [--synckey <n>] [--offset <n>]` | Page through articles; `--synckey` starts a delta refresh and conflicts with `--offset` |
+| `weread-omni public-accounts resolve-article <docUrl>` | Resolve an article URL to its WeRead review ID |
+| `weread-omni public-accounts paid-content <docUrl>` | Attempt to fetch an entitled protected article |
+| `weread-omni public-accounts subscribe <accountId>` | Subscribe to a public account |
+| `weread-omni public-accounts unsubscribe <accountId> [-y, --yes]` | Unsubscribe from a public account |
+| `weread-omni public-accounts feed <accountId\|subscriptions> --format <rss\|atom\|json> --out <file> [--limit <n>]` | Create a feed file |
+| `weread-omni public-accounts export <accountId> --out <directory> [--limit <n>]` | Create an article export directory |
 
 ### Notes and reviews
 
 | Command | Purpose |
 | --- | --- |
-| `weread notes notebooks [--count <n>] [--last-sort <n>]` | List books with notes |
-| `weread notes recent [--count <n>]` | List recent notes and highlights |
-| `weread notes bookmarks <bookId> [--synckey <n>]` | List your highlights with their text |
-| `weread notes mine <bookId> [--synckey <n>] [--count <n>]` | List your notes for a book |
-| `weread notes best <bookId> [--synckey <n>] [--count <n>] [--max-idx <n>] [--chapter-uid <n>]` | List popular highlights |
-| `weread notes read-reviews <bookId> <chapterUid> --reviews <json>` | Read thoughts under popular-highlight ranges |
-| `weread notes underlines <bookId> <chapterUid> [--synckey <n>]` | Get per-chapter highlight statistics without text |
-| `weread notes add-bookmark <bookId> <chapterUid> <range> <markText> [--type <n>] [--style <n>] [--color-style <n>] [--book-version <n>] [--chapter-name <name>] [--context-abstract <text>]` | Add a highlight |
-| `weread notes update-bookmark <bookmarkId> --style <n> [--color-style <n>]` | Change a highlight's style |
-| `weread notes remove-bookmark <bookmarkId> [-y, --yes]` | Remove one of your highlights |
-| `weread review list <bookId> [--list-type <n>] [--list-mode <n>] [--mine <n>] [--synckey <n>] [--count <n>] [--max-idx <n>]` | List reviews |
-| `weread review single <reviewId> [--comments-count <n>] [--comments-direction <n>] [--likes-count <n>] [--likes-direction <n>] [--synckey <n>]` | Get one thought or review |
-| `weread review add <bookId> <content> [--star <n>] [--type <n>] [--range <range>] [--abstract <text>] [--chapter-uid <n>]` | Post a review or thought |
-| `weread review edit <reviewId> <content>` | Edit one of your reviews or thoughts |
-| `weread review delete <reviewId> [-y, --yes]` | Delete a review |
+| `weread-omni notes notebooks [--count <n>] [--last-sort <n>]` | List books with notes |
+| `weread-omni notes recent [--count <n>]` | List recent notes and highlights |
+| `weread-omni notes bookmarks <bookId> [--synckey <n>]` | List your highlights with their text |
+| `weread-omni notes mine <bookId> [--synckey <n>] [--count <n>]` | List your notes for a book |
+| `weread-omni notes best <bookId> [--synckey <n>] [--count <n>] [--max-idx <n>] [--chapter-uid <n>]` | List popular highlights |
+| `weread-omni notes read-reviews <bookId> <chapterUid> --reviews <json>` | Read thoughts under popular-highlight ranges |
+| `weread-omni notes underlines <bookId> <chapterUid> [--synckey <n>]` | Get per-chapter highlight statistics without text |
+| `weread-omni notes add-bookmark <bookId> <chapterUid> <range> <markText> [--type <n>] [--style <n>] [--color-style <n>] [--book-version <n>] [--chapter-name <name>] [--context-abstract <text>]` | Add a highlight |
+| `weread-omni notes update-bookmark <bookmarkId> --style <n> [--color-style <n>]` | Change a highlight's style |
+| `weread-omni notes remove-bookmark <bookmarkId> [-y, --yes]` | Remove one of your highlights |
+| `weread-omni review list <bookId> [--list-type <n>] [--list-mode <n>] [--mine <n>] [--synckey <n>] [--count <n>] [--max-idx <n>]` | List reviews |
+| `weread-omni review single <reviewId> [--comments-count <n>] [--comments-direction <n>] [--likes-count <n>] [--likes-direction <n>] [--synckey <n>]` | Get one thought or review |
+| `weread-omni review add <bookId> <content> [--star <n>] [--type <n>] [--range <range>] [--abstract <text>] [--chapter-uid <n>]` | Post a review or thought |
+| `weread-omni review edit <reviewId> <content>` | Edit one of your reviews or thoughts |
+| `weread-omni review delete <reviewId> [-y, --yes]` | Delete a review |
 
 ### Statistics, discovery, AI, and import
 
 | Command | Purpose |
 | --- | --- |
-| `weread read-data detail [--mode <mode>] [--base-time <n>]` | Get reading statistics |
-| `weread discover recommend [--count <n>] [--max-idx <n>]` | Get book recommendations |
-| `weread discover similar <bookId> [--count <n>] [--max-idx <n>] [--session-id <id>]` | Find similar books |
-| `weread ai ask-book <bookId> <query> [--intent <intent>] [--max-polls <n>] [--delay-cap-ms <ms>]` | Ask WeRead AI about a book |
-| `weread ai suggest <bookId> [--chapter-uid <n>] [--toolbar] [--range <range>] [--mp-review-id <id>]` | Get suggested questions |
-| `weread import book <path>` | Import a personal book |
+| `weread-omni read-data detail [--mode <mode>] [--base-time <n>]` | Get reading statistics |
+| `weread-omni discover recommend [--count <n>] [--max-idx <n>]` | Get book recommendations |
+| `weread-omni discover similar <bookId> [--count <n>] [--max-idx <n>] [--session-id <id>]` | Find similar books |
+| `weread-omni ai ask-book <bookId> <query> [--intent <intent>] [--max-polls <n>] [--delay-cap-ms <ms>]` | Ask WeRead AI about a book |
+| `weread-omni ai suggest <bookId> [--chapter-uid <n>] [--toolbar] [--range <range>] [--mp-review-id <id>]` | Get suggested questions |
+| `weread-omni import book <path>` | Import a personal book |
 
 ### Search scopes and paging
 

--- a/README.en.md
+++ b/README.en.md
@@ -33,6 +33,8 @@ weread-omni doctor --json
 weread-omni search books "The Three-Body Problem" --json
 ```
 
+The command is `weread-omni`. `0.1.0` installed it as `weread`, which collides with the official Skill's command, so it was renamed in `0.1.1`. Upgrading does not remove the old `weread` binary — reinstall if you had `0.1.0`.
+
 `weread-omni login` presents a single E-Ink QR code — scan it once with your WeRead account.
 
 QR codes and progress go to stderr. On success, the JSON written to stdout contains only the account alias, client ID, `vid`, and device ID—never tokens. `weread-omni doctor` checks the active installation, authentication, and one read-only request.
@@ -48,9 +50,9 @@ weread-omni accounts use work --json
 weread-omni --account default shelf sync --json
 ```
 
-An alias must start with a lowercase letter or digit. The remaining characters may be lowercase letters, digits, `-`, or `_`, for a maximum length of 64. If a command omits `--account`, the only configured account is selected automatically. With multiple accounts, `WEREAD_ACCOUNT` takes precedence over the default saved by `weread-omni accounts use <alias>`. If neither selects an account, the CLI asks you to be explicit.
+An alias must start with a lowercase letter or digit. The remaining characters may be lowercase letters, digits, `-`, or `_`, for a maximum length of 64. If a command omits `--account`, the only configured account is selected automatically. With multiple accounts, `WEREAD_ACCOUNT` takes precedence over the default saved by `weread-omni accounts use <alias>`. If neither selects an account, an interactive terminal lists every account and lets you choose by number or alias; non-interactive commands must pass `--account` or set a default.
 
-Credentials live under `~/.config/weread/accounts/<alias>/` by default. Directories use mode `0700`, and files use `0600`. Set `WEREAD_CONFIG_DIR` to move the configuration root. Every `WEREAD_*` variable read by the project is documented in [`.env.example`](https://github.com/teng-lin/weread-omni/blob/v0.1.0/.env.example).
+Credentials live under `~/.config/weread/accounts/<alias>/` by default. Directories use mode `0700`, and files use `0600`. Set `WEREAD_CONFIG_DIR` to move the configuration root. Every `WEREAD_*` variable read by the project is documented in [`.env.example`](https://github.com/teng-lin/weread-omni/blob/v0.1.1/.env.example).
 
 ### Install the agent skill
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ weread-omni doctor --json
 weread-omni search books "三体" --json
 ```
 
+命令名是 `weread-omni`。`0.1.0` 装的是 `weread`，和官方 Skill 的命令重名，所以从 `0.1.1` 起改掉了；升级不会删掉旧的 `weread`，装过 `0.1.0` 的话重装一次即可。
+
 `weread-omni login` 显示一个二维码，用微信读书账号扫一次即可。
 
 登录成功后的 JSON 只包含账号别名、客户端 ID、`vid` 和设备 ID，不包含任何令牌。`weread-omni doctor` 会核对当前安装和登录状态，并发起一次只读请求确认连接正常。
@@ -49,9 +51,9 @@ weread-omni accounts use work --json
 weread-omni --account default shelf sync --json
 ```
 
-账号别名的首字符必须是小写字母或数字，后面可以使用小写字母、数字、`-` 和 `_`，总长不超过 64 个字符。命令没有指定 `--account` 时，只有一个账号就直接使用它；有多个账号时，先读取 `WEREAD_ACCOUNT`，再读取 `weread-omni accounts use <alias>` 保存的默认账号。两者都没有设置时，命令会要求你明确选择。
+账号别名的首字符必须是小写字母或数字，后面可以使用小写字母、数字、`-` 和 `_`，总长不超过 64 个字符。命令没有指定 `--account` 时，只有一个账号就直接使用它；有多个账号时，先读取 `WEREAD_ACCOUNT`，再读取 `weread-omni accounts use <alias>` 保存的默认账号。两者都没有设置时，交互式终端会列出所有账号，支持按编号或别名选择；非交互式命令必须传入 `--account` 或设置默认账号。
 
-登录信息默认保存在 `~/.config/weread/accounts/<alias>/`。目录权限为 `0700`，文件权限为 `0600`。设置 `WEREAD_CONFIG_DIR` 可以更改配置目录。项目读取的 `WEREAD_*` 变量都列在 [`.env.example`](https://github.com/teng-lin/weread-omni/blob/v0.1.0/.env.example) 中。
+登录信息默认保存在 `~/.config/weread/accounts/<alias>/`。目录权限为 `0700`，文件权限为 `0600`。设置 `WEREAD_CONFIG_DIR` 可以更改配置目录。项目读取的 `WEREAD_*` 变量都列在 [`.env.example`](https://github.com/teng-lin/weread-omni/blob/v0.1.1/.env.example) 中。
 
 ### 安装 agent skill
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 weread-omni 是微信读书的全能智能体技能和非官方 SDK。微信扫码即可用，支持 40 项读写操作，远超官方支持的 6 项只读技能。
 
-40 项操作只有一套实现，三个入口共用：`weread` 命令行，每条命令都能输出 JSON；一套类型完整的 TypeScript SDK；还有仓库自带的 agent skill。
+40 项操作只有一套实现，三个入口共用：`weread-omni` 命令行，每条命令都能输出 JSON；一套类型完整的 TypeScript SDK；还有仓库自带的 agent skill。
 
 这是一个非官方项目，与腾讯及微信读书没有隶属关系，也未获得其认可或支持。
 
@@ -28,14 +28,14 @@ weread-omni 是微信读书的全能智能体技能和非官方 SDK。微信扫�
 
 ```bash
 npm install --global weread-omni
-weread login --json
-weread doctor --json
-weread search books "三体" --json
+weread-omni login --json
+weread-omni doctor --json
+weread-omni search books "三体" --json
 ```
 
-`weread login` 显示一个二维码，用微信读书账号扫一次即可。
+`weread-omni login` 显示一个二维码，用微信读书账号扫一次即可。
 
-登录成功后的 JSON 只包含账号别名、客户端 ID、`vid` 和设备 ID，不包含任何令牌。`weread doctor` 会核对当前安装和登录状态，并发起一次只读请求确认连接正常。
+登录成功后的 JSON 只包含账号别名、客户端 ID、`vid` 和设备 ID，不包含任何令牌。`weread-omni doctor` 会核对当前安装和登录状态，并发起一次只读请求确认连接正常。
 
 
 ### 账号与登录信息
@@ -43,19 +43,19 @@ weread search books "三体" --json
 第一次不带 `--account` 登录时，账号别名为 `default`。要添加其他账号，可以自己指定别名：
 
 ```bash
-weread --account work login --json
-weread accounts --json
-weread accounts use work --json
-weread --account default shelf sync --json
+weread-omni --account work login --json
+weread-omni accounts --json
+weread-omni accounts use work --json
+weread-omni --account default shelf sync --json
 ```
 
-账号别名的首字符必须是小写字母或数字，后面可以使用小写字母、数字、`-` 和 `_`，总长不超过 64 个字符。命令没有指定 `--account` 时，只有一个账号就直接使用它；有多个账号时，先读取 `WEREAD_ACCOUNT`，再读取 `weread accounts use <alias>` 保存的默认账号。两者都没有设置时，命令会要求你明确选择。
+账号别名的首字符必须是小写字母或数字，后面可以使用小写字母、数字、`-` 和 `_`，总长不超过 64 个字符。命令没有指定 `--account` 时，只有一个账号就直接使用它；有多个账号时，先读取 `WEREAD_ACCOUNT`，再读取 `weread-omni accounts use <alias>` 保存的默认账号。两者都没有设置时，命令会要求你明确选择。
 
 登录信息默认保存在 `~/.config/weread/accounts/<alias>/`。目录权限为 `0700`，文件权限为 `0600`。设置 `WEREAD_CONFIG_DIR` 可以更改配置目录。项目读取的 `WEREAD_*` 变量都列在 [`.env.example`](https://github.com/teng-lin/weread-omni/blob/v0.1.0/.env.example) 中。
 
 ### 安装 agent skill
 
-仓库附带的 `weread` skill 会告诉 agent 怎样检查登录状态、调用 JSON CLI、正确翻页，并在写操作前向你确认。它不会安装 `weread` 命令，因此要先完成上面的安装和登录。
+仓库附带的 `weread-omni` skill 会告诉 agent 怎样检查登录状态、调用 JSON CLI、正确翻页，并在写操作前向你确认。它不会安装 `weread-omni` 命令，因此要先完成上面的安装和登录。
 
 使用 [skills CLI](https://github.com/vercel-labs/skills) 安装：
 
@@ -80,18 +80,18 @@ npx skills update weread
 
 ## 常用命令
 
-所有命令都支持 `--json`。给 agent 调用时建议始终使用 JSON 输出。完整参数以 `weread <命令> --help` 为准。
+所有命令都支持 `--json`。给 agent 调用时建议始终使用 JSON 输出。完整参数以 `weread-omni <命令> --help` 为准。
 
 ### 搜索与阅读
 
 ```bash
-weread search books "三体" --json
-weread book info BOOK_ID --json
-weread book chapters BOOK_ID --json
-weread notes bookmarks BOOK_ID --json
-weread read-data detail --mode annually --json
-weread discover similar BOOK_ID --json
-weread ai ask-book BOOK_ID "这本书的核心论点是什么？" --json
+weread-omni search books "三体" --json
+weread-omni book info BOOK_ID --json
+weread-omni book chapters BOOK_ID --json
+weread-omni notes bookmarks BOOK_ID --json
+weread-omni read-data detail --mode annually --json
+weread-omni discover similar BOOK_ID --json
+weread-omni ai ask-book BOOK_ID "这本书的核心论点是什么？" --json
 ```
 
 `book chapters` 返回后续命令需要的 `chapterUid`。
@@ -99,12 +99,12 @@ weread ai ask-book BOOK_ID "这本书的核心论点是什么？" --json
 ### 书架、划线与点评
 
 ```bash
-weread shelf sync --count 50 --json
-weread shelf add BOOK_ID --json
-weread shelf mark-reading BOOK_ID --json
+weread-omni shelf sync --count 50 --json
+weread-omni shelf add BOOK_ID --json
+weread-omni shelf mark-reading BOOK_ID --json
 
-weread notes add-bookmark BOOK_ID CHAPTER_UID "1-20" "要划线的原文" --json
-weread review add BOOK_ID "读完后的想法" --star 80 --json
+weread-omni notes add-bookmark BOOK_ID CHAPTER_UID "1-20" "要划线的原文" --json
+weread-omni review add BOOK_ID "读完后的想法" --star 80 --json
 ```
 
 `shelf pin`、`set-private`、`mark-finished` 和 `mark-reading` 默认会置顶、设为私密、标记读完或标记在读。分别加 `--no-top`、`--no-secret`、`--no-finished` 或 `--no-reading` 可以取消对应状态。点评星级只能填 `20`、`40`、`60`、`80`、`100`，对应一到五星。
@@ -114,13 +114,13 @@ weread review add BOOK_ID "读完后的想法" --star 80 --json
 订阅前先搜索并核对准确的 `MP_WXS_<数字>` ID：
 
 ```bash
-weread search books "公众号名称" --scope 2 --json
-weread public-accounts subscribe MP_WXS_1234567890 --json
-weread public-accounts articles MP_WXS_1234567890 --count 20 --json
+weread-omni search books "公众号名称" --scope 2 --json
+weread-omni public-accounts subscribe MP_WXS_1234567890 --json
+weread-omni public-accounts articles MP_WXS_1234567890 --count 20 --json
 
-weread public-accounts feed MP_WXS_1234567890 --format json --out ./account.feed.json --limit 50 --json
-weread public-accounts feed subscriptions --format rss --out ./subscriptions.xml --limit 50 --json
-weread public-accounts export MP_WXS_1234567890 --out ./account-archive --limit 100 --json
+weread-omni public-accounts feed MP_WXS_1234567890 --format json --out ./account.feed.json --limit 50 --json
+weread-omni public-accounts feed subscriptions --format rss --out ./subscriptions.xml --limit 50 --json
+weread-omni public-accounts export MP_WXS_1234567890 --out ./account-archive --limit 100 --json
 ```
 
 Feed 和导出默认处理 20 篇文章，`--limit` 最大为 100。命令不会覆盖已有文件或目录。文章正文只会从经过校验的 HTTPS `mp.weixin.qq.com/s` 地址下载；遇到 JavaScript 验证或验证码时会把情况记进诊断信息，不会尝试绕过。
@@ -128,7 +128,7 @@ Feed 和导出默认处理 20 篇文章，`--limit` 最大为 100。命令不会
 ### 导入个人书籍
 
 ```bash
-weread import book ./my-book.epub --json
+weread-omni import book ./my-book.epub --json
 ```
 
 支持 EPUB、PDF、MOBI、TXT 和 AZW3。单个文件默认不超过 200 MiB，可以用 `WEREAD_MAX_UPLOAD_BYTES` 调整。
@@ -138,9 +138,9 @@ weread import book ./my-book.epub --json
 CLI 默认把图书信息、目录和已经下载的公众号文章保存到本地。再次读取相同内容时会直接使用本地副本。
 
 ```bash
-weread library path --json
-weread library status --json
-weread library verify --json
+weread-omni library path --json
+weread-omni library status --json
+weread-omni library verify --json
 ```
 
 | 选项 | 作用 |
@@ -168,76 +168,76 @@ weread library verify --json
 
 | 命令 | 用途 |
 | --- | --- |
-| `weread login` | 登录或重新登录所选账号 |
-| `weread accounts` | 列出账号及客户端 ID |
-| `weread accounts use <alias>` | 设置省略 `--account` 时默认用哪个账号 |
-| `weread whoami` | 显示所选账号的身份信息：`vid`、设备 ID 和凭据来源，不含令牌 |
-| `weread doctor` | 检查安装、登录和连接状态 |
-| `weread library path` | 显示本地内容库路径 |
-| `weread library status` | 统计本地内容库中的内容 |
-| `weread library verify` | 检查数据库和已保存文件 |
+| `weread-omni login` | 登录或重新登录所选账号 |
+| `weread-omni accounts` | 列出账号及客户端 ID |
+| `weread-omni accounts use <alias>` | 设置省略 `--account` 时默认用哪个账号 |
+| `weread-omni whoami` | 显示所选账号的身份信息：`vid`、设备 ID 和凭据来源，不含令牌 |
+| `weread-omni doctor` | 检查安装、登录和连接状态 |
+| `weread-omni library path` | 显示本地内容库路径 |
+| `weread-omni library status` | 统计本地内容库中的内容 |
+| `weread-omni library verify` | 检查数据库和已保存文件 |
 
 ### 图书与书架
 
 | 命令 | 用途 |
 | --- | --- |
-| `weread search books <keyword> [--scope <n>] [--count <n>] [--max-idx <n>]` | 搜索书城，默认范围为电子书 |
-| `weread search suggest <keyword> [--count <n>]` | 获取搜索自动补全词 |
-| `weread book info <bookId>` | 查看图书信息 |
-| `weread book detail <bookId> [--count <n>]` | 查看书籍配图，以及同作者、同出版社、同版权方、同分类的书单 |
-| `weread book chapters <bookId>` | 查看目录 |
-| `weread book progress <bookId>` | 查看阅读进度 |
-| `weread shelf sync [--count <n>] [--offset <n>] [--full]` | 分页查看精简书架；`--full` 返回原始响应 |
-| `weread shelf add <bookId>` | 加入书架 |
-| `weread shelf delete <bookId> [-y, --yes]` | 从书架删除 |
-| `weread shelf pin <bookId> [--no-top]` | 置顶或取消置顶 |
-| `weread shelf set-private <bookId> [--no-secret]` | 设为私密或公开 |
-| `weread shelf mark-finished <bookId> [--no-finished]` | 标记读完或撤销 |
-| `weread shelf mark-reading <bookId> [--no-reading]` | 标记在读或撤销 |
+| `weread-omni search books <keyword> [--scope <n>] [--count <n>] [--max-idx <n>]` | 搜索书城，默认范围为电子书 |
+| `weread-omni search suggest <keyword> [--count <n>]` | 获取搜索自动补全词 |
+| `weread-omni book info <bookId>` | 查看图书信息 |
+| `weread-omni book detail <bookId> [--count <n>]` | 查看书籍配图，以及同作者、同出版社、同版权方、同分类的书单 |
+| `weread-omni book chapters <bookId>` | 查看目录 |
+| `weread-omni book progress <bookId>` | 查看阅读进度 |
+| `weread-omni shelf sync [--count <n>] [--offset <n>] [--full]` | 分页查看精简书架；`--full` 返回原始响应 |
+| `weread-omni shelf add <bookId>` | 加入书架 |
+| `weread-omni shelf delete <bookId> [-y, --yes]` | 从书架删除 |
+| `weread-omni shelf pin <bookId> [--no-top]` | 置顶或取消置顶 |
+| `weread-omni shelf set-private <bookId> [--no-secret]` | 设为私密或公开 |
+| `weread-omni shelf mark-finished <bookId> [--no-finished]` | 标记读完或撤销 |
+| `weread-omni shelf mark-reading <bookId> [--no-reading]` | 标记在读或撤销 |
 
 ### 公众号
 
 | 命令 | 用途 |
 | --- | --- |
-| `weread public-accounts subscriptions [--count <n>] [--offset <n>]` | 分页查看已订阅公众号 |
-| `weread public-accounts articles <accountId> [--count <n>] [--synckey <n>] [--offset <n>]` | 分页查看文章；增量刷新可传 `--synckey`，但不能和 `--offset` 同时使用 |
-| `weread public-accounts resolve-article <docUrl>` | 从文章链接解析微信读书点评 ID |
-| `weread public-accounts paid-content <docUrl>` | 尝试读取有权限的付费文章正文 |
-| `weread public-accounts subscribe <accountId>` | 订阅公众号 |
-| `weread public-accounts unsubscribe <accountId> [-y, --yes]` | 取消订阅 |
-| `weread public-accounts feed <accountId\|subscriptions> --format <rss\|atom\|json> --out <file> [--limit <n>]` | 新建 Feed 文件 |
-| `weread public-accounts export <accountId> --out <directory> [--limit <n>]` | 新建文章导出目录 |
+| `weread-omni public-accounts subscriptions [--count <n>] [--offset <n>]` | 分页查看已订阅公众号 |
+| `weread-omni public-accounts articles <accountId> [--count <n>] [--synckey <n>] [--offset <n>]` | 分页查看文章；增量刷新可传 `--synckey`，但不能和 `--offset` 同时使用 |
+| `weread-omni public-accounts resolve-article <docUrl>` | 从文章链接解析微信读书点评 ID |
+| `weread-omni public-accounts paid-content <docUrl>` | 尝试读取有权限的付费文章正文 |
+| `weread-omni public-accounts subscribe <accountId>` | 订阅公众号 |
+| `weread-omni public-accounts unsubscribe <accountId> [-y, --yes]` | 取消订阅 |
+| `weread-omni public-accounts feed <accountId\|subscriptions> --format <rss\|atom\|json> --out <file> [--limit <n>]` | 新建 Feed 文件 |
+| `weread-omni public-accounts export <accountId> --out <directory> [--limit <n>]` | 新建文章导出目录 |
 
 ### 笔记与点评
 
 | 命令 | 用途 |
 | --- | --- |
-| `weread notes notebooks [--count <n>] [--last-sort <n>]` | 查看有笔记的书 |
-| `weread notes recent [--count <n>]` | 查看最近的笔记和划线 |
-| `weread notes bookmarks <bookId> [--synckey <n>]` | 查看自己的划线及原文 |
-| `weread notes mine <bookId> [--synckey <n>] [--count <n>]` | 查看自己的笔记 |
-| `weread notes best <bookId> [--synckey <n>] [--count <n>] [--max-idx <n>] [--chapter-uid <n>]` | 查看热门划线 |
-| `weread notes read-reviews <bookId> <chapterUid> --reviews <json>` | 查看热门划线范围下的想法 |
-| `weread notes underlines <bookId> <chapterUid> [--synckey <n>]` | 查看章节划线热度，不含原文 |
-| `weread notes add-bookmark <bookId> <chapterUid> <range> <markText> [--type <n>] [--style <n>] [--color-style <n>] [--book-version <n>] [--chapter-name <name>] [--context-abstract <text>]` | 添加划线 |
-| `weread notes update-bookmark <bookmarkId> --style <n> [--color-style <n>]` | 修改划线样式 |
-| `weread notes remove-bookmark <bookmarkId> [-y, --yes]` | 删除自己的划线 |
-| `weread review list <bookId> [--list-type <n>] [--list-mode <n>] [--mine <n>] [--synckey <n>] [--count <n>] [--max-idx <n>]` | 查看点评 |
-| `weread review single <reviewId> [--comments-count <n>] [--comments-direction <n>] [--likes-count <n>] [--likes-direction <n>] [--synckey <n>]` | 查看一条想法或点评 |
-| `weread review add <bookId> <content> [--star <n>] [--type <n>] [--range <range>] [--abstract <text>] [--chapter-uid <n>]` | 发表点评或想法 |
-| `weread review edit <reviewId> <content>` | 修改自己的点评或想法 |
-| `weread review delete <reviewId> [-y, --yes]` | 删除点评 |
+| `weread-omni notes notebooks [--count <n>] [--last-sort <n>]` | 查看有笔记的书 |
+| `weread-omni notes recent [--count <n>]` | 查看最近的笔记和划线 |
+| `weread-omni notes bookmarks <bookId> [--synckey <n>]` | 查看自己的划线及原文 |
+| `weread-omni notes mine <bookId> [--synckey <n>] [--count <n>]` | 查看自己的笔记 |
+| `weread-omni notes best <bookId> [--synckey <n>] [--count <n>] [--max-idx <n>] [--chapter-uid <n>]` | 查看热门划线 |
+| `weread-omni notes read-reviews <bookId> <chapterUid> --reviews <json>` | 查看热门划线范围下的想法 |
+| `weread-omni notes underlines <bookId> <chapterUid> [--synckey <n>]` | 查看章节划线热度，不含原文 |
+| `weread-omni notes add-bookmark <bookId> <chapterUid> <range> <markText> [--type <n>] [--style <n>] [--color-style <n>] [--book-version <n>] [--chapter-name <name>] [--context-abstract <text>]` | 添加划线 |
+| `weread-omni notes update-bookmark <bookmarkId> --style <n> [--color-style <n>]` | 修改划线样式 |
+| `weread-omni notes remove-bookmark <bookmarkId> [-y, --yes]` | 删除自己的划线 |
+| `weread-omni review list <bookId> [--list-type <n>] [--list-mode <n>] [--mine <n>] [--synckey <n>] [--count <n>] [--max-idx <n>]` | 查看点评 |
+| `weread-omni review single <reviewId> [--comments-count <n>] [--comments-direction <n>] [--likes-count <n>] [--likes-direction <n>] [--synckey <n>]` | 查看一条想法或点评 |
+| `weread-omni review add <bookId> <content> [--star <n>] [--type <n>] [--range <range>] [--abstract <text>] [--chapter-uid <n>]` | 发表点评或想法 |
+| `weread-omni review edit <reviewId> <content>` | 修改自己的点评或想法 |
+| `weread-omni review delete <reviewId> [-y, --yes]` | 删除点评 |
 
 ### 统计、推荐、AI 与导入
 
 | 命令 | 用途 |
 | --- | --- |
-| `weread read-data detail [--mode <mode>] [--base-time <n>]` | 查看阅读统计 |
-| `weread discover recommend [--count <n>] [--max-idx <n>]` | 查看推荐图书 |
-| `weread discover similar <bookId> [--count <n>] [--max-idx <n>] [--session-id <id>]` | 查找相似图书 |
-| `weread ai ask-book <bookId> <query> [--intent <intent>] [--max-polls <n>] [--delay-cap-ms <ms>]` | 向微信读书 AI 提问 |
-| `weread ai suggest <bookId> [--chapter-uid <n>] [--toolbar] [--range <range>] [--mp-review-id <id>]` | 获取建议问题 |
-| `weread import book <path>` | 导入个人书籍 |
+| `weread-omni read-data detail [--mode <mode>] [--base-time <n>]` | 查看阅读统计 |
+| `weread-omni discover recommend [--count <n>] [--max-idx <n>]` | 查看推荐图书 |
+| `weread-omni discover similar <bookId> [--count <n>] [--max-idx <n>] [--session-id <id>]` | 查找相似图书 |
+| `weread-omni ai ask-book <bookId> <query> [--intent <intent>] [--max-polls <n>] [--delay-cap-ms <ms>]` | 向微信读书 AI 提问 |
+| `weread-omni ai suggest <bookId> [--chapter-uid <n>] [--toolbar] [--range <range>] [--mp-review-id <id>]` | 获取建议问题 |
+| `weread-omni import book <path>` | 导入个人书籍 |
 
 ### 搜索范围与翻页
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 
 ## The content library
 
-`weread` keeps downloaded content under `WEREAD_LIBRARY_DIR` (default
+`weread-omni` keeps downloaded content under `WEREAD_LIBRARY_DIR` (default
 `~/.local/share/weread/library`), separate from the credential directory. The
 database and every stored payload are written `0600` inside a `0700` directory,
 matching the rest of the package.
@@ -15,7 +15,7 @@ is far likelier than a small configuration file to be swept into a backup or a
 synchronised folder.
 
 Nothing is deleted automatically. There is no retention policy and no eviction:
-removing stored content means deleting the directory. `weread library verify`
+removing stored content means deleting the directory. `weread-omni library verify`
 reports damage but never removes anything.
 
 ## Supported versions
@@ -72,7 +72,7 @@ Out of scope:
   with, endorsed by, or supported by Tencent or WeRead. Report a flaw in the
   upstream service to Tencent, not here.
 - Findings that only restate a documented design decision — for example that
-  write gates are permitted by default, or that `weread import book` reads the
+  write gates are permitted by default, or that `weread-omni import book` reads the
   local path it is given.
 - Consequences of running the CLI as a different user, or of copying an account
   profile out of `WEREAD_CONFIG_DIR`. Those files are the operator's risk.

--- a/docs/api-stability-policy.md
+++ b/docs/api-stability-policy.md
@@ -9,7 +9,7 @@ The public TypeScript SDK core is the compatibility boundary. Patch releases
 keep that surface backward compatible; breaking SDK changes require a minor
 release.
 
-The `weread` CLI, including its human-readable and JSON output, is experimental.
+The `weread-omni` CLI, including its human-readable and JSON output, is experimental.
 It may change in a minor release. The packaged agent skill follows the current
 CLI and is not a separate compatibility contract.
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     }
   },
   "bin": {
-    "weread": "./dist/cli.js"
+    "weread-omni": "./dist/cli.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weread-omni",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Everything the official WeRead (微信读书 / WeChat Reading) Agent Skill does — plus public accounts, RSS/Atom/JSON feeds, book imports, WeRead AI, and write access to your highlights and shelf. One canonical surface of 40 operations through an agent skill, TypeScript SDK, and CLI.",
   "keywords": [
     "weread",

--- a/skills/weread/SKILL.md
+++ b/skills/weread/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weread
-description: Search WeRead, inspect books and reading data, manage the bookshelf, public-account subscriptions and reviews, read and write highlights and notes, build private article feeds and archives, ask WeRead AI, or import a personal book through the installed `weread` JSON CLI. Use for requests involving 微信读书, WeChat Reading, a user's WeRead shelf, public accounts, articles, highlights, notes, reviews, reading statistics, recommendations, or book lookup.
+description: Search WeRead, inspect books and reading data, manage the bookshelf, public-account subscriptions and reviews, read and write highlights and notes, build private article feeds and archives, ask WeRead AI, or import a personal book through the installed `weread-omni` JSON CLI. Use for requests involving 微信读书, WeChat Reading, a user's WeRead shelf, public accounts, articles, highlights, notes, reviews, reading statistics, recommendations, or book lookup.
 ---
 
 # WeRead
@@ -14,7 +14,7 @@ tokens.
 
 Choose exactly one account for the session and preserve it through every CLI
 call. Use the alias supplied by the user or operator. If none was supplied,
-`weread accounts --json` must show exactly one configured account. In the
+`weread-omni accounts --json` must show exactly one configured account. In the
 examples below, `$ACCOUNT` means that alias. Do not switch accounts after a
 failure.
 
@@ -27,7 +27,7 @@ never unset it or retry against another account on the user's behalf.
 Before the first authenticated operation, run:
 
 ```bash
-weread --account "$ACCOUNT" doctor --json
+weread-omni --account "$ACCOUNT" doctor --json
 ```
 
 Proceed only when the result has `ok: true`, `cli.package:
@@ -37,7 +37,7 @@ error, require the same `cli.package` in the JSON error before following its
 account-specific hint; malformed or unreadable state must be corrected or
 removed first. Retry `doctor` once with the same account. If it returns
 non-JSON or names another
-package, stop and report the path from `command -v weread`; do not guess
+package, stop and report the path from `command -v weread-omni`; do not guess
 another command.
 
 ## Read workflow
@@ -52,22 +52,22 @@ offer `--refresh` to refetch and replace it; `--no-library` skips the library
 entirely for one command. Never present stored content as freshly fetched.
 
 ```bash
-weread --account "$ACCOUNT" search books "三体" --json
-weread --account "$ACCOUNT" search books "刘慈欣" --scope 6 --json
-weread --account "$ACCOUNT" book info BOOK_ID --json
-weread --account "$ACCOUNT" shelf sync --count 20 --json
-weread --account "$ACCOUNT" public-accounts subscriptions --count 20 --json
-weread --account "$ACCOUNT" public-accounts articles MP_WXS_123 --count 20 --json
-weread --account "$ACCOUNT" public-accounts resolve-article 'https://mp.weixin.qq.com/s/ARTICLE' --json
-weread --account "$ACCOUNT" notes notebooks --count 10 --json
-weread --account "$ACCOUNT" notes recent --count 10 --json
-weread --account "$ACCOUNT" notes mine BOOK_ID --count 10 --json
-weread --account "$ACCOUNT" notes underlines BOOK_ID CHAPTER_UID --json
-weread --account "$ACCOUNT" notes read-reviews BOOK_ID CHAPTER_UID --reviews '[{"range":"393-401","count":10}]' --json
-weread --account "$ACCOUNT" review single REVIEW_ID --json
-weread --account "$ACCOUNT" read-data detail --mode weekly --json
-weread --account "$ACCOUNT" discover recommend --count 10 --json
-weread --account "$ACCOUNT" ai ask-book BOOK_ID "Summarize the central argument" --json
+weread-omni --account "$ACCOUNT" search books "三体" --json
+weread-omni --account "$ACCOUNT" search books "刘慈欣" --scope 6 --json
+weread-omni --account "$ACCOUNT" book info BOOK_ID --json
+weread-omni --account "$ACCOUNT" shelf sync --count 20 --json
+weread-omni --account "$ACCOUNT" public-accounts subscriptions --count 20 --json
+weread-omni --account "$ACCOUNT" public-accounts articles MP_WXS_123 --count 20 --json
+weread-omni --account "$ACCOUNT" public-accounts resolve-article 'https://mp.weixin.qq.com/s/ARTICLE' --json
+weread-omni --account "$ACCOUNT" notes notebooks --count 10 --json
+weread-omni --account "$ACCOUNT" notes recent --count 10 --json
+weread-omni --account "$ACCOUNT" notes mine BOOK_ID --count 10 --json
+weread-omni --account "$ACCOUNT" notes underlines BOOK_ID CHAPTER_UID --json
+weread-omni --account "$ACCOUNT" notes read-reviews BOOK_ID CHAPTER_UID --reviews '[{"range":"393-401","count":10}]' --json
+weread-omni --account "$ACCOUNT" review single REVIEW_ID --json
+weread-omni --account "$ACCOUNT" read-data detail --mode weekly --json
+weread-omni --account "$ACCOUNT" discover recommend --count 10 --json
+weread-omni --account "$ACCOUNT" ai ask-book BOOK_ID "Summarize the central argument" --json
 ```
 
 `search books` defaults to `--scope 10` for ebooks. Choose the scope from the
@@ -111,7 +111,7 @@ questions.
 
 For public accounts, follow this sequence exactly:
 
-1. Search with `weread --account "$ACCOUNT" search books KEYWORD --scope 2 --json`.
+1. Search with `weread-omni --account "$ACCOUNT" search books KEYWORD --scope 2 --json`.
 2. Show the matches and have the user choose the exact `MP_WXS_<digits>` ID.
    Never auto-select or auto-subscribe the first fuzzy match.
 3. Subscribe only when requested, then use `public-accounts subscriptions`,
@@ -119,11 +119,11 @@ For public accounts, follow this sequence exactly:
 4. Unsubscribe only after confirming the exact account.
 
 ```bash
-weread --account "$ACCOUNT" public-accounts subscribe MP_WXS_123 --json
-weread --account "$ACCOUNT" public-accounts feed MP_WXS_123 --format rss --out /private/path/feed.xml --json
-weread --account "$ACCOUNT" public-accounts feed subscriptions --format json --out /private/path/feed.json --json
-weread --account "$ACCOUNT" public-accounts export MP_WXS_123 --out /private/path/archive --json
-weread --account "$ACCOUNT" public-accounts unsubscribe MP_WXS_123 --yes --json
+weread-omni --account "$ACCOUNT" public-accounts subscribe MP_WXS_123 --json
+weread-omni --account "$ACCOUNT" public-accounts feed MP_WXS_123 --format rss --out /private/path/feed.xml --json
+weread-omni --account "$ACCOUNT" public-accounts feed subscriptions --format json --out /private/path/feed.json --json
+weread-omni --account "$ACCOUNT" public-accounts export MP_WXS_123 --out /private/path/archive --json
+weread-omni --account "$ACCOUNT" public-accounts unsubscribe MP_WXS_123 --yes --json
 ```
 
 Feed and export outputs contain at most 20 items by default and 100 maximum.
@@ -148,10 +148,10 @@ Run a write only when the user explicitly requests that change. State the
 target before acting. Do not infer consent from a prior read.
 
 ```bash
-weread --account "$ACCOUNT" shelf add BOOK_ID --json
-weread --account "$ACCOUNT" review add BOOK_ID "A concise review" --star 100 --json
-weread --account "$ACCOUNT" review edit REVIEW_ID "Replacement text" --json
-weread --account "$ACCOUNT" import book /absolute/path/to/book.epub --json
+weread-omni --account "$ACCOUNT" shelf add BOOK_ID --json
+weread-omni --account "$ACCOUNT" review add BOOK_ID "A concise review" --star 100 --json
+weread-omni --account "$ACCOUNT" review edit REVIEW_ID "Replacement text" --json
+weread-omni --account "$ACCOUNT" import book /absolute/path/to/book.epub --json
 ```
 
 `import book` accepts an EPUB, PDF, MOBI, TXT, or AZW3 file the user already
@@ -161,14 +161,14 @@ Shelf state changes use the positive state by default and a negated option for
 the reverse:
 
 ```bash
-weread --account "$ACCOUNT" shelf pin BOOK_ID --json
-weread --account "$ACCOUNT" shelf pin BOOK_ID --no-top --json
-weread --account "$ACCOUNT" shelf set-private BOOK_ID --json
-weread --account "$ACCOUNT" shelf set-private BOOK_ID --no-secret --json
-weread --account "$ACCOUNT" shelf mark-finished BOOK_ID --json
-weread --account "$ACCOUNT" shelf mark-finished BOOK_ID --no-finished --json
-weread --account "$ACCOUNT" shelf mark-reading BOOK_ID --json
-weread --account "$ACCOUNT" shelf mark-reading BOOK_ID --no-reading --json
+weread-omni --account "$ACCOUNT" shelf pin BOOK_ID --json
+weread-omni --account "$ACCOUNT" shelf pin BOOK_ID --no-top --json
+weread-omni --account "$ACCOUNT" shelf set-private BOOK_ID --json
+weread-omni --account "$ACCOUNT" shelf set-private BOOK_ID --no-secret --json
+weread-omni --account "$ACCOUNT" shelf mark-finished BOOK_ID --json
+weread-omni --account "$ACCOUNT" shelf mark-finished BOOK_ID --no-finished --json
+weread-omni --account "$ACCOUNT" shelf mark-reading BOOK_ID --json
+weread-omni --account "$ACCOUNT" shelf mark-reading BOOK_ID --no-reading --json
 ```
 
 Review ratings use the protocol scale `20`, `40`, `60`, `80`, or `100`.
@@ -176,18 +176,18 @@ Review ratings use the protocol scale `20`, `40`, `60`, `80`, or `100`.
 Add a highlight (划线) with the chapter, character range, and highlighted text:
 
 ```bash
-weread --account "$ACCOUNT" notes add-bookmark BOOK_ID CHAPTER_UID "777-778" "the highlighted text" --json
-weread --account "$ACCOUNT" notes update-bookmark BOOKMARK_ID --style 2 --color-style 5 --json
+weread-omni --account "$ACCOUNT" notes add-bookmark BOOK_ID CHAPTER_UID "777-778" "the highlighted text" --json
+weread-omni --account "$ACCOUNT" notes update-bookmark BOOKMARK_ID --style 2 --color-style 5 --json
 ```
 
 Deletion is destructive. Confirm the exact target with the user, then include
 `--yes`; never retry a failed write blindly.
 
 ```bash
-weread --account "$ACCOUNT" shelf delete BOOK_ID --yes --json
-weread --account "$ACCOUNT" notes remove-bookmark BOOKMARK_ID --yes --json
-weread --account "$ACCOUNT" review delete REVIEW_ID --yes --json
-weread --account "$ACCOUNT" public-accounts unsubscribe MP_WXS_123 --yes --json
+weread-omni --account "$ACCOUNT" shelf delete BOOK_ID --yes --json
+weread-omni --account "$ACCOUNT" notes remove-bookmark BOOKMARK_ID --yes --json
+weread-omni --account "$ACCOUNT" review delete REVIEW_ID --yes --json
+weread-omni --account "$ACCOUNT" public-accounts unsubscribe MP_WXS_123 --yes --json
 ```
 
 ## Result handling

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -148,12 +148,12 @@ export class AccountManager {
       return selected;
     }
     const configured = listAccountAliases(this.#env);
-    if (configured.length === 0) throw new AuthError("no WeRead accounts are configured; run weread login");
+    if (configured.length === 0) throw new AuthError("no WeRead accounts are configured; run weread-omni login");
     if (configured.length === 1) return configured;
     const preferred = this.defaultAccount();
     if (preferred !== undefined) return [preferred];
     throw new AuthError(
-      `multiple WeRead accounts are configured (${configured.join(", ")}); pass --account, or set a default with "weread accounts use <alias>"`,
+      `multiple WeRead accounts are configured (${configured.join(", ")}); pass --account, or set a default with "weread-omni accounts use <alias>"`,
     );
   }
 

--- a/src/api/mobile-client.ts
+++ b/src/api/mobile-client.ts
@@ -82,9 +82,9 @@ export class MobileApiClient {
     this.#credentials = options.credentials ? { ...options.credentials } : undefined;
     this.#env = options.env ?? process.env;
     this.#profile = options.profile ?? einkProfile();
-    // The credential file this client reads. `weread login` writes accounts elsewhere, so this
+    // The credential file this client reads. `weread-omni login` writes accounts elsewhere, so this
     // names a file for a direct SDK client or a `createProgram` embedder -- never for the shipped
-    // `weread` binary, which routes through AccountManager. An explicit "" is a deliberate request
+    // `weread-omni` binary, which routes through AccountManager. An explicit "" is a deliberate request
     // for the unsuffixed store and is preserved; only an absent option falls back.
     this.#store = options.store ?? "eink";
     this.#fetchImpl = options.fetchImpl ?? fetch;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import { redact, stripErrorPrefix } from "./redact.js";
 
 const loginRecoveryHint = (store: string): string => {
   const selector = STORE_NAME.test(store) ? ` --account ${store}` : "";
-  return `Run weread${selector} login --json, scan the QR codes, then retry.`;
+  return `Run weread-omni${selector} login --json, scan the QR codes, then retry.`;
 };
 
 function authRecoveryHint(error: AuthError, store: string, loginSupported: boolean): string {
@@ -252,7 +252,7 @@ function jsonError(error: unknown, message: string, store: string, loginSupporte
     // machine consumer can act on — and reading it only off `WeReadApiError` left it as prose.
     if (error.ambiguous) payload.ambiguous = true;
   } else if (isAmbiguousImportOutcome(error)) {
-    // `weread import book` can fail after `/cos/notify` with the book still created. Same
+    // `weread-omni import book` can fail after `/cos/notify` with the book still created. Same
     // must-not-retry contract as above, different error taxonomy.
     payload.ambiguous = true;
     payload.phase = error.phase;
@@ -318,7 +318,7 @@ export function createProgram<TClient extends CliOperationsClient = MobileApiCli
     });
   const isTTY = dependencies.isTTY ?? process.stdin.isTTY === true;
   const program = new Command()
-    .name("weread")
+    .name("weread-omni")
     .description("WeChat Reading command line interface")
     .version(CLI_METADATA.version, "-V, --version", "print the installed version")
     .option("--json", "write raw JSON")
@@ -415,11 +415,11 @@ export function createProgram<TClient extends CliOperationsClient = MobileApiCli
       const configured = accountManager.accounts();
       if (configured.length === 1) return configured[0]?.account as string;
       if (configured.length === 0 && create) return "default";
-      if (configured.length === 0) throw new Error("no WeRead accounts are configured; run weread login");
+      if (configured.length === 0) throw new Error("no WeRead accounts are configured; run weread-omni login");
       const preferred = accountManager.defaultAccount();
       if (preferred !== undefined) return preferred;
       throw new Error(
-        `multiple WeRead accounts are configured (${configured.map(({ account }) => account).join(", ")}); pass --account, or set a default with "weread accounts use <alias>"`,
+        `multiple WeRead accounts are configured (${configured.map(({ account }) => account).join(", ")}); pass --account, or set a default with "weread-omni accounts use <alias>"`,
       );
     };
     const accounts = program.command("accounts").description("List configured accounts");
@@ -707,7 +707,7 @@ export async function runCli<TClient extends CliOperationsClient = MobileApiClie
       }
     }
     // Ask the parser, not the raw argv: a positional argument that merely looks like the flag
-    // (weread shelf delete -- --json) must not switch the error format. The argv fallback applies
+    // (weread-omni shelf delete -- --json) must not switch the error format. The argv fallback applies
     // only when construction failed, so there is no parser to ask.
     const json = program ? Boolean(program.opts().json) : argv.includes("--json");
     const message = stripErrorPrefix(redact(error instanceof Error ? error.message : String(error)));
@@ -805,7 +805,7 @@ export async function runAccountCli(
         },
       ];
       if (parsed.accounts.length === 0) {
-        effectiveArgv = [argv[0] ?? "node", argv[1] ?? "weread", "--account", opened.account, ...argv.slice(2)];
+        effectiveArgv = [argv[0] ?? "node", argv[1] ?? "weread-omni", "--account", opened.account, ...argv.slice(2)];
       }
     }
     return await runCli(effectiveArgv, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ const CLI_METADATA: { package: string; version: string } = (() => {
   }
 })();
 
-import { AccountManager, type OpenAccount } from "./accounts.js";
+import { AccountManager, type AccountSummary, type OpenAccount } from "./accounts.js";
 import type { CanonicalClient } from "./api/client.js";
 import { createEinkClient, type MobileApiClient } from "./api/mobile-client.js";
 import { isAmbiguousImportOutcome } from "./api/resources/import.js";
@@ -757,6 +757,46 @@ function rootArguments(argv: readonly string[]): { command?: string; accounts: s
 
 export interface AccountCliDependencies extends Omit<CliDependencies, "accountManager" | "stores" | "getClient"> {
   accountManager: AccountManager;
+  /** Choose an account when an interactive command has several candidates and no default. */
+  selectAccount?: AccountSelector;
+}
+
+export type AccountSelector = (accounts: readonly AccountSummary[]) => Promise<string> | string;
+
+async function promptForAccount(accounts: readonly AccountSummary[], stderr: OutputWriter): Promise<string> {
+  stderr.write("Multiple WeRead accounts are configured:\n");
+  for (const [index, { account, client }] of accounts.entries()) {
+    stderr.write(`  ${index + 1}. ${account} (${client})\n`);
+  }
+
+  const prompt = createInterface({
+    input: process.stdin,
+    // readline writes the question to `output`, and never writes anything but a string there, so a
+    // one-method adapter is enough to keep the question on the same channel as the list above.
+    output: { write: (chunk: string) => stderr.write(chunk) } as NodeJS.WritableStream,
+    terminal: false,
+  });
+  // `question()` never settles when stdin reaches EOF -- Ctrl-D, or a closed pipe -- so without
+  // this the CLI would hang forever and the `finally` below would never run. `close` does fire, so
+  // it aborts the pending question and the catch turns that into an ordinary refusal.
+  const cancelled = new AbortController();
+  prompt.once("close", () => cancelled.abort());
+  try {
+    const answer = (
+      await prompt.question("Select an account by number or alias: ", { signal: cancelled.signal })
+    ).trim();
+    // An alias made of digits is still an alias; the list position is only the fallback reading.
+    const selected =
+      accounts.find(({ account }) => account === answer) ??
+      (/^\d+$/.test(answer) ? accounts[Number(answer) - 1] : undefined);
+    if (!selected) throw new AuthError(`unknown account selection ${JSON.stringify(answer)}`);
+    return selected.account;
+  } catch (error) {
+    if (cancelled.signal.aborted) throw new AuthError("no account was selected");
+    throw error;
+  } finally {
+    prompt.close();
+  }
 }
 
 export async function runAccountCli(
@@ -782,7 +822,25 @@ export async function runAccountCli(
       argv.includes("-V");
     let stores: readonly CliStore[] | undefined;
     if (!management) {
-      const selected = dependencies.accountManager.select(parsed.accounts);
+      // Asking is the last resort: only when nothing else picks the account -- no --account, more
+      // than one configured, no recorded default -- and only when someone is there to answer.
+      //
+      // `--json` disqualifies a caller even from a terminal. It declares the output machine-read,
+      // the same way it already forces `--yes` on destructive commands, and a caller piping JSON
+      // into another program still inherits the terminal's stdin: without this check that pipeline
+      // blocks on a question nobody sees. Such callers keep the old "pass --account" error.
+      //
+      // Commander has not parsed yet here, so `--json` is read from argv the way the flags below are.
+      const interactive =
+        parsed.accounts.length === 0 &&
+        !argv.includes("--json") &&
+        (dependencies.isTTY ?? process.stdin.isTTY === true);
+      const candidates = interactive ? dependencies.accountManager.accounts() : [];
+      const shouldPrompt = candidates.length > 1 && dependencies.accountManager.defaultAccount() === undefined;
+      const selectAccount = dependencies.selectAccount ?? ((accounts) => promptForAccount(accounts, stderr));
+      const selected = dependencies.accountManager.select(
+        shouldPrompt ? [await selectAccount(candidates)] : parsed.accounts,
+      );
       if (selected.length !== 1) throw new AuthError("ordinary CLI commands accept exactly one account");
       const opened: OpenAccount = await dependencies.accountManager.open(selected[0] as string);
       // Commander has not parsed yet at this point, so the flags are read from argv directly --

--- a/test/api-surface.snapshot.md
+++ b/test/api-surface.snapshot.md
@@ -210,9 +210,10 @@
 - `toTransportError` — function — dist/errors.d.ts
 - `withContentLibrary` — function — dist/library/cached-client.d.ts
 
-### `weread-omni/cli` — dist/cli.d.ts (20 exports)
+### `weread-omni/cli` — dist/cli.d.ts (21 exports)
 
 - `AccountCliDependencies` — interface — dist/cli.d.ts
+- `AccountSelector` — type — dist/cli.d.ts
 - `CliDependencies` — interface — dist/cli.d.ts
 - `CliIdentity` — interface — dist/cli.d.ts
 - `CliOperationsClient` — type — dist/cli/commands.d.ts
@@ -286,6 +287,7 @@ interface AccountCliDependencies extends Omit<CliDependencies<MobileApiClient>, 
   library?: PublicAccountLibrary
   libraryMode?: PublicAccountLibraryMode
   renderQr?: ((text: string) => Promise<string | undefined>)
+  selectAccount?: AccountSelector
   signal?: AbortSignal
   stderr?: OutputWriter
   stdout?: OutputWriter
@@ -330,6 +332,12 @@ interface AccountManagerOptions {
   fetchImpl?: { (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | Request | URL, init?: RequestInit | undefined): Promise<Response>; }
   plugins?: readonly ClientPlugin[]
 }
+```
+
+### `AccountSelector` — dist/cli.d.ts
+
+```ts
+type AccountSelector = (accounts: readonly AccountSummary[]) => string | Promise<string>
 ```
 
 ### `AccountSummary` — dist/accounts.d.ts

--- a/test/e2e/packed-runtime/packed-runtime.test.ts
+++ b/test/e2e/packed-runtime/packed-runtime.test.ts
@@ -188,7 +188,7 @@ describe("packed CLI", () => {
 
     const leaves = new Set<string>();
     for (const resource of new Set(expected.map((leaf) => leaf.split(" ")[0] as string))) {
-      const help = await runBin("weread", [resource, "--help"], credentialEnv);
+      const help = await runBin("weread-omni", [resource, "--help"], credentialEnv);
       expect(help.code, `${resource} --help: ${help.stderr}`).toBe(0);
       for (const line of help.stdout.split("\n")) {
         const action = /^\s{2}([a-z][a-z-]*)\b/.exec(line)?.[1];
@@ -199,7 +199,7 @@ describe("packed CLI", () => {
   }, 120_000);
 
   it("prints machine-readable identity without contacting anything", async () => {
-    const result = await runBin("weread", ["whoami", "--json"], credentialEnv);
+    const result = await runBin("weread-omni", ["whoami", "--json"], credentialEnv);
     expect(result.code).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       vid: "42",
@@ -209,7 +209,7 @@ describe("packed CLI", () => {
   }, 30_000);
 
   it("emits exactly one JSON document for a successful read", async () => {
-    const result = await runBin("weread", ["book", "info", "9787532776870", "--json"], {
+    const result = await runBin("weread-omni", ["book", "info", "9787532776870", "--json"], {
       ...credentialEnv,
       NODE_OPTIONS: `--import ${JSON.stringify(pathToFileURL(fakeUpstream).href)}`,
     });
@@ -224,7 +224,7 @@ describe("packed CLI", () => {
   }, 30_000);
 
   it("reports an upstream refusal on stderr and a non-zero exit, leaving stdout clean", async () => {
-    const result = await runBin("weread", ["book", "detail", "9787532776870", "--json"], {
+    const result = await runBin("weread-omni", ["book", "detail", "9787532776870", "--json"], {
       ...credentialEnv,
       NODE_OPTIONS: `--import ${JSON.stringify(pathToFileURL(fakeUpstream).href)}`,
     });
@@ -234,7 +234,7 @@ describe("packed CLI", () => {
   }, 30_000);
 
   it("treats an early-closing stdout consumer as successful pipeline completion", async () => {
-    const result = await runBinWithClosedStdout("weread", ["book", "info", "pipe-stress", "--json"], {
+    const result = await runBinWithClosedStdout("weread-omni", ["book", "info", "pipe-stress", "--json"], {
       ...credentialEnv,
       NODE_OPTIONS: `--import ${JSON.stringify(pathToFileURL(fakeUpstream).href)}`,
     });

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -243,12 +243,12 @@ describe("public CLI topology", () => {
   it("renders help without loading credentials", async () => {
     const deps = dependencies();
 
-    await expect(createProgram(deps.value).parseAsync(["node", "weread", "--help"])).rejects.toMatchObject({
+    await expect(createProgram(deps.value).parseAsync(["node", "weread-omni", "--help"])).rejects.toMatchObject({
       code: "commander.helpDisplayed",
       exitCode: 0,
     });
     expect(deps.stdout.read()).toMatchInlineSnapshot(`
-      "Usage: weread [options] [command]
+      "Usage: weread-omni [options] [command]
 
       WeChat Reading command line interface
 
@@ -281,8 +281,8 @@ describe("public CLI topology", () => {
   });
 
   it.each([
-    { argv: ["node", "weread"], usage: "Usage: weread [options] [command]" },
-    { argv: ["node", "weread", "book"], usage: "Usage: weread book [options] [command]" },
+    { argv: ["node", "weread-omni"], usage: "Usage: weread-omni [options] [command]" },
+    { argv: ["node", "weread-omni", "book"], usage: "Usage: weread-omni book [options] [command]" },
   ])("renders contextual help for an incomplete command", async ({ argv, usage }) => {
     const deps = dependencies();
 
@@ -297,7 +297,7 @@ describe("public CLI topology", () => {
     async (...args) => {
       const deps = dependencies();
 
-      await expect(runCli(["node", "weread", ...args], deps.value)).resolves.toBe(1);
+      await expect(runCli(["node", "weread-omni", ...args], deps.value)).resolves.toBe(1);
       expect(deps.stdout.read()).toBe("");
       expect(JSON.parse(deps.stderr.read())).toEqual({ error: "missing command" });
       expect(deps.value.getClient).not.toHaveBeenCalled();
@@ -307,8 +307,8 @@ describe("public CLI topology", () => {
   it("keeps explicit help successful and human-readable with --json present", async () => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", "book", "--help", "--json"], deps.value)).resolves.toBe(0);
-    expect(deps.stdout.read()).toContain("Usage: weread book");
+    await expect(runCli(["node", "weread-omni", "book", "--help", "--json"], deps.value)).resolves.toBe(0);
+    expect(deps.stdout.read()).toContain("Usage: weread-omni book");
     expect(deps.stderr.read()).toBe("");
   });
 
@@ -328,7 +328,7 @@ describe("public CLI topology", () => {
   ])("renders declared defaults and bounds in help for $argv", async ({ argv, expected }) => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", ...argv], deps.value)).resolves.toBe(0);
+    await expect(runCli(["node", "weread-omni", ...argv], deps.value)).resolves.toBe(0);
     const help = deps.stdout.read().replace(/\s+/g, " ");
     for (const text of expected) expect(help).toContain(text);
     expect(deps.stderr.read()).toBe("");
@@ -349,7 +349,7 @@ describe("public CLI topology", () => {
   ])("rejects removed command %s before loading credentials", async (...args) => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", ...args], deps.value)).resolves.toBe(1);
+    await expect(runCli(["node", "weread-omni", ...args], deps.value)).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stderr.read()).toContain("unknown command");
   });
@@ -626,7 +626,7 @@ describe("public CLI operation projection", () => {
     const client = { [namespace]: { [action]: method } } as unknown as MobileApiClient;
 
     await expect(
-      runCli(["node", "weread", "--json", ...args], {
+      runCli(["node", "weread-omni", "--json", ...args], {
         getClient: () => client,
         env: enabledGates,
         stdout: stdout.stream,
@@ -645,7 +645,7 @@ describe("public CLI operation projection", () => {
     const client = { publicAccounts: { articles } } as unknown as MobileApiClient;
 
     await expect(
-      runCli(["node", "weread", "public-accounts", "articles", "MP_WXS_1", "--synckey", "9", "--json"], {
+      runCli(["node", "weread-omni", "public-accounts", "articles", "MP_WXS_1", "--synckey", "9", "--json"], {
         getClient: () => client,
         stdout: sink().stream,
         stderr: sink().stream,
@@ -656,7 +656,7 @@ describe("public CLI operation projection", () => {
     const deps = dependencies();
     await expect(
       runCli(
-        ["node", "weread", "public-accounts", "articles", "MP_WXS_1", "--synckey", "9", "--offset", "2"],
+        ["node", "weread-omni", "public-accounts", "articles", "MP_WXS_1", "--synckey", "9", "--offset", "2"],
         deps.value,
       ),
     ).resolves.toBe(1);
@@ -675,7 +675,7 @@ describe("public CLI operation projection", () => {
     }));
 
     await expect(
-      runCli(["node", "weread", "shelf", "sync", "--count", "1", "--offset", "1", "--json"], {
+      runCli(["node", "weread-omni", "shelf", "sync", "--count", "1", "--offset", "1", "--json"], {
         getClient: () => ({ shelf: { sync } }) as unknown as MobileApiClient,
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -696,7 +696,7 @@ describe("public CLI operation projection", () => {
     const deps = dependencies();
 
     await expect(
-      runCli(["node", "weread", "shelf", "sync", "--full", "--count", "1", "--json"], deps.value),
+      runCli(["node", "weread-omni", "shelf", "sync", "--full", "--count", "1", "--json"], deps.value),
     ).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stderr.read()).toContain("cannot be used with option");
@@ -717,7 +717,7 @@ describe("public CLI lifecycle and extension seam", () => {
     const stderr = sink();
 
     await expect(
-      runCli(["node", "weread", "doctor", "--json"], {
+      runCli(["node", "weread-omni", "doctor", "--json"], {
         env,
         getClient: () => ({ shelf: { sync } }) as unknown as MobileApiClient,
         stdout: stdout.stream,
@@ -747,7 +747,7 @@ describe("public CLI lifecycle and extension seam", () => {
 
     const human = sink();
     await expect(
-      runCli(["node", "weread", "doctor"], {
+      runCli(["node", "weread-omni", "doctor"], {
         env,
         getClient: () => ({ shelf: { sync } }) as unknown as MobileApiClient,
         stdout: human.stream,
@@ -781,7 +781,7 @@ describe("public CLI lifecycle and extension seam", () => {
     const stdout = sink();
 
     await expect(
-      runCli(["node", "weread", "whoami", "--json"], { env, stdout: stdout.stream, stderr: sink().stream }),
+      runCli(["node", "weread-omni", "whoami", "--json"], { env, stdout: stdout.stream, stderr: sink().stream }),
     ).resolves.toBe(0);
     expect(JSON.parse(stdout.read())).toEqual({ vid: "123", deviceId: fixtureCredentials.deviceId, source: "file" });
   });
@@ -802,7 +802,7 @@ describe("public CLI lifecycle and extension seam", () => {
     });
 
     await expect(
-      runCli(["node", "weread", "extension-probe"], {
+      runCli(["node", "weread-omni", "extension-probe"], {
         getClient: () => client,
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -821,7 +821,7 @@ describe("CLI store routing and capability policy", () => {
     const deps = dependencies();
 
     await expect(
-      runCli(["node", "weread", "--account", "personal", "--account", "work", "book", "info", "b"], deps.value),
+      runCli(["node", "weread-omni", "--account", "personal", "--account", "work", "book", "info", "b"], deps.value),
     ).resolves.toBe(1);
 
     expect(deps.value.getClient).not.toHaveBeenCalled();
@@ -837,7 +837,7 @@ describe("CLI store routing and capability policy", () => {
     const stderr = sink();
 
     await expect(
-      runCli(["node", "weread", "--account", "personal", "--account", "work", "private", "mcp"], {
+      runCli(["node", "weread-omni", "--account", "personal", "--account", "work", "private", "mcp"], {
         stores,
         stderr: stderr.stream,
         extendStoreProgram: (program) => {
@@ -859,17 +859,17 @@ describe("CLI store routing and capability policy", () => {
 
     const cases = [
       {
-        argv: ["node", "weread", "--account", "flag", "whoami", "--json"],
+        argv: ["node", "weread-omni", "--account", "flag", "whoami", "--json"],
         dependencies: { env: { WEREAD_CONFIG_DIR: directory }, store: "dependency" },
         expected: "flag",
       },
       {
-        argv: ["node", "weread", "whoami", "--json"],
+        argv: ["node", "weread-omni", "whoami", "--json"],
         dependencies: { env: { WEREAD_CONFIG_DIR: directory }, store: "dependency" },
         expected: "dependency",
       },
       {
-        argv: ["node", "weread", "whoami", "--json"],
+        argv: ["node", "weread-omni", "whoami", "--json"],
         dependencies: { env: { WEREAD_CONFIG_DIR: directory } },
         expected: "eink",
       },
@@ -891,7 +891,9 @@ describe("CLI store routing and capability policy", () => {
   it("rejects a different selector for a fixed injected client before calling it", async () => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", "--account", "work", "book", "info", "b"], deps.value)).resolves.toBe(1);
+    await expect(runCli(["node", "weread-omni", "--account", "work", "book", "info", "b"], deps.value)).resolves.toBe(
+      1,
+    );
 
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stderr.read()).toContain('fixed to store "eink"');
@@ -925,7 +927,7 @@ describe("CLI store routing and capability policy", () => {
 
     const unsupportedError = sink();
     await expect(
-      runCli(["node", "weread", "book", "info", "b", "--json"], {
+      runCli(["node", "weread-omni", "book", "info", "b", "--json"], {
         env,
         store: "alpha",
         stores,
@@ -938,7 +940,7 @@ describe("CLI store routing and capability policy", () => {
 
     const selectedOutput = sink();
     await expect(
-      runCli(["node", "weread", "--account", "beta", "book", "info", "b", "--json"], {
+      runCli(["node", "weread-omni", "--account", "beta", "book", "info", "b", "--json"], {
         env,
         stores,
         stdout: selectedOutput.stream,
@@ -950,7 +952,7 @@ describe("CLI store routing and capability policy", () => {
 
     const identityOutput = sink();
     await expect(
-      runCli(["node", "weread", "whoami", "--json"], {
+      runCli(["node", "weread-omni", "whoami", "--json"], {
         env,
         store: "alpha",
         stores,
@@ -1017,7 +1019,7 @@ describe("CLI store routing and capability policy", () => {
     });
 
     await expect(
-      runCli(["node", "weread", "--account", "beta", "store-probe"], {
+      runCli(["node", "weread-omni", "--account", "beta", "store-probe"], {
         store: "alpha",
         stores,
         stdout: stdout.stream,
@@ -1051,7 +1053,7 @@ describe("CLI store routing and capability policy", () => {
     const getClient = vi.fn(() => new MobileApiClient({ credentials: fixtureCredentials, env: {} }));
 
     await expect(
-      runCli(["node", "weread", "book", "info", "b"], {
+      runCli(["node", "weread-omni", "book", "info", "b"], {
         stores: [{ name: "alpha", backend: "mobile-api", client: {} }],
         getClient,
         stderr: stderr.stream,
@@ -1091,13 +1093,13 @@ describe("CLI store routing and capability policy", () => {
       stores,
     });
     expect(leafCommands(disabledProgram)).not.toContain("shelf add");
-    await expect(disabledProgram.parseAsync(["node", "weread", "shelf", "add", "b"])).rejects.toThrow();
+    await expect(disabledProgram.parseAsync(["node", "weread-omni", "shelf", "add", "b"])).rejects.toThrow();
     expect(add).not.toHaveBeenCalled();
 
     // Policy is a startup snapshot: visibility and dispatch cannot diverge if an embedder mutates
     // its configuration object after constructing the command tree.
     env.WEREAD_READONLY = "1";
-    await program.parseAsync(["node", "weread", "shelf", "add", "b"]);
+    await program.parseAsync(["node", "weread-omni", "shelf", "add", "b"]);
     expect(add).toHaveBeenCalledOnce();
   });
 });
@@ -1115,7 +1117,7 @@ describe("public CLI output and failures", () => {
     });
 
     await expect(
-      runCli(["node", "weread", "book", "info", "b", "--json"], {
+      runCli(["node", "weread-omni", "book", "info", "b", "--json"], {
         getClient: () => ({ book: { info } }) as unknown as MobileApiClient,
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -1158,7 +1160,7 @@ describe("public CLI output and failures", () => {
     const stderr = sink();
 
     await expect(
-      runCli(["node", "weread", "public-accounts", "export", "MP_WXS_1", "--out", destination, "--json"], {
+      runCli(["node", "weread-omni", "public-accounts", "export", "MP_WXS_1", "--out", destination, "--json"], {
         getClient: () => client,
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -1202,7 +1204,7 @@ describe("public CLI output and failures", () => {
     });
 
     await expect(
-      runCli(["node", "weread", "book", "info", "b", "--json"], {
+      runCli(["node", "weread-omni", "book", "info", "b", "--json"], {
         getClient: () => ({ book: { info } }) as unknown as MobileApiClient,
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -1231,7 +1233,7 @@ describe("public CLI output and failures", () => {
     ] as const) {
       const stderr = sink();
       await expect(
-        runCli(["node", "weread", "--account", store, "book", "info", "b", "--json"], {
+        runCli(["node", "weread-omni", "--account", store, "book", "info", "b", "--json"], {
           stores: [{ name: store, backend: `${store}-api`, client }],
           stdout: sink().stream,
           stderr: stderr.stream,
@@ -1242,7 +1244,7 @@ describe("public CLI output and failures", () => {
 
     const stderr = sink();
     await expect(
-      runCli(["node", "weread", "book", "info", "b", "--json"], {
+      runCli(["node", "weread-omni", "book", "info", "b", "--json"], {
         store: "beta",
         stores: [
           { name: "alpha", backend: "mobile-api", client: { book: { info } } },
@@ -1260,7 +1262,7 @@ describe("public CLI output and failures", () => {
   it("requires confirmation for destructive non-interactive actions", async () => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", "shelf", "delete", "b", "--json"], deps.value)).resolves.toBe(1);
+    await expect(runCli(["node", "weread-omni", "shelf", "delete", "b", "--json"], deps.value)).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stderr.read()).toContain("requires --yes");
   });
@@ -1269,7 +1271,7 @@ describe("public CLI output and failures", () => {
     const deps = dependencies();
 
     await expect(
-      runCli(["node", "weread", "notes", "remove-bookmark", "bookmark", "--json"], deps.value),
+      runCli(["node", "weread-omni", "notes", "remove-bookmark", "bookmark", "--json"], deps.value),
     ).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stderr.read()).toContain("requires --yes");
@@ -1279,7 +1281,7 @@ describe("public CLI output and failures", () => {
     const deps = dependencies();
 
     await expect(
-      runCli(["node", "weread", "public-accounts", "unsubscribe", "MP_WXS_1", "--json"], deps.value),
+      runCli(["node", "weread-omni", "public-accounts", "unsubscribe", "MP_WXS_1", "--json"], deps.value),
     ).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stderr.read()).toContain("requires --yes");
@@ -1298,7 +1300,7 @@ describe("public CLI output and failures", () => {
   ])("validates public-account command %s before loading credentials", async (...args) => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", ...args, "--json"], deps.value)).resolves.toBe(1);
+    await expect(runCli(["node", "weread-omni", ...args, "--json"], deps.value)).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
   });
 
@@ -1329,7 +1331,7 @@ describe("public CLI output and failures", () => {
     const feedPath = join(directory, "feed.json");
     await expect(
       runCli(
-        ["node", "weread", "public-accounts", "feed", "MP_WXS_1", "--format", "json", "--out", feedPath, "--json"],
+        ["node", "weread-omni", "public-accounts", "feed", "MP_WXS_1", "--format", "json", "--out", feedPath, "--json"],
         { getClient: () => client, stdout: feedOut.stream, stderr: sink().stream },
       ),
     ).resolves.toBe(0);
@@ -1338,7 +1340,7 @@ describe("public CLI output and failures", () => {
     const archiveOut = sink();
     const archivePath = join(directory, "archive");
     await expect(
-      runCli(["node", "weread", "public-accounts", "export", "MP_WXS_1", "--out", archivePath, "--json"], {
+      runCli(["node", "weread-omni", "public-accounts", "export", "MP_WXS_1", "--out", archivePath, "--json"], {
         getClient: () => client,
         stdout: archiveOut.stream,
         stderr: sink().stream,
@@ -1365,7 +1367,18 @@ describe("public CLI output and failures", () => {
 
     await expect(
       runCli(
-        ["node", "weread", "public-accounts", "feed", "MP_WXS_1", "--format", "json", "--out", destination, "--json"],
+        [
+          "node",
+          "weread-omni",
+          "public-accounts",
+          "feed",
+          "MP_WXS_1",
+          "--format",
+          "json",
+          "--out",
+          destination,
+          "--json",
+        ],
         {
           getClient: () =>
             ({
@@ -1388,7 +1401,7 @@ describe("public CLI output and failures", () => {
     deps.value.isTTY = true;
     deps.value.confirm = vi.fn(async () => false);
 
-    await expect(runCli(["node", "weread", "shelf", "delete", "b"], deps.value)).resolves.toBe(0);
+    await expect(runCli(["node", "weread-omni", "shelf", "delete", "b"], deps.value)).resolves.toBe(0);
     expect(deps.value.confirm).toHaveBeenCalledWith("Deleting this book?");
     expect(deps.value.getClient).not.toHaveBeenCalled();
     expect(deps.stdout.read()).toBe("Cancelled.\n");
@@ -1409,14 +1422,14 @@ describe("public CLI output and failures", () => {
   ])("rejects invalid numeric option %s before loading the client", async (...args) => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", ...args, "--json"], deps.value)).resolves.toBe(1);
+    await expect(runCli(["node", "weread-omni", ...args, "--json"], deps.value)).resolves.toBe(1);
     expect(deps.value.getClient).not.toHaveBeenCalled();
   });
 
   it("rejects blank required write text before transport", async () => {
     const deps = dependencies();
 
-    await expect(runCli(["node", "weread", "review", "add", "b", " ", "--json"], deps.value)).resolves.toBe(1);
+    await expect(runCli(["node", "weread-omni", "review", "add", "b", " ", "--json"], deps.value)).resolves.toBe(1);
     expect(deps.stderr.read()).toContain("content");
   });
 
@@ -1458,7 +1471,7 @@ describe("CLI error-format selection", () => {
     // Previously decided by argv.includes("--json"), so a bookId of "--json" after the `--`
     // separator flipped the error format even though the parser never saw the option.
     const written: string[] = [];
-    const code = await runCli(["node", "weread", "shelf", "delete", "--", "--json"], {
+    const code = await runCli(["node", "weread-omni", "shelf", "delete", "--", "--json"], {
       stderr: { write: (chunk: string) => written.push(chunk) } as never,
       isTTY: false,
       getClient: () => ({}) as never,

--- a/test/integration/library-cli.test.ts
+++ b/test/integration/library-cli.test.ts
@@ -50,9 +50,10 @@ function harness(): {
   };
 }
 
-const run = (deps: CliDependencies, ...args: string[]): Promise<number> => runCli(["node", "weread", ...args], deps);
+const run = (deps: CliDependencies, ...args: string[]): Promise<number> =>
+  runCli(["node", "weread-omni", ...args], deps);
 
-describe("weread library", () => {
+describe("weread-omni library", () => {
   it("reports where content is stored without creating anything", async () => {
     const test = harness();
     rmSync(test.root, { recursive: true, force: true });

--- a/test/integration/library-public-accounts-cli.test.ts
+++ b/test/integration/library-public-accounts-cli.test.ts
@@ -10,7 +10,7 @@ import { ContentLibrary } from "../../src/library/store.js";
  * Proof that the open library actually reaches the artifact commands.
  *
  * The store itself and the public-account paths are covered elsewhere. What is only true if the
- * wiring is right is that `weread public-accounts export` hands its library down far enough to be
+ * wiring is right is that `weread-omni public-accounts export` hands its library down far enough to be
  * consulted, and nothing below the command layer can show that.
  */
 
@@ -102,7 +102,7 @@ function stubSource(): () => number {
   return () => calls;
 }
 
-describe("weread public-accounts export with a library", () => {
+describe("weread-omni public-accounts export with a library", () => {
   it("consults the library the CLI opened, so a second export fetches nothing", async () => {
     const library = await ContentLibrary.open({
       vid: "42",

--- a/test/integration/qrlogin-polling.test.ts
+++ b/test/integration/qrlogin-polling.test.ts
@@ -3,7 +3,7 @@ import { exchange, pollForCode } from "../../src/auth/qrlogin.js";
 import { AuthError, TransportError } from "../../src/errors.js";
 
 // The QR poll is a long-lived loop the user is waiting on. Its cancellation and deadline
-// behaviour is what decides whether `weread login` can be interrupted, and whether a login that
+// behaviour is what decides whether `weread-omni login` can be interrupted, and whether a login that
 // will never complete says so instead of spinning — neither is visible from the happy path.
 
 const wx = (body: unknown, status = 200): Response =>

--- a/test/live/read-only.test.ts
+++ b/test/live/read-only.test.ts
@@ -6,7 +6,7 @@ import { createEinkClient } from "../../src/index.js";
 describe.skipIf(process.env.WEREAD_LIVE !== "1")("read-only live release probe", () => {
   // The probe drives the SDK directly, and the SDK deliberately never touches this Node-wide
   // default — only a process entry point may. This vitest worker is the process entry point here,
-  // so it stands in for `weread` and applies the same setting it does. Without it
+  // so it stands in for `weread-omni` and applies the same setting it does. Without it
   // the probe fails intermittently with `network error`, because Node's 250 ms Happy Eyeballs
   // budget expires a few milliseconds before a ~255 ms connect to WeRead completes.
   beforeAll(() => {

--- a/test/support/platform.ts
+++ b/test/support/platform.ts
@@ -1,7 +1,7 @@
 /**
  * Platform differences the end-to-end suites have to account for.
  *
- * These suites drive `npm` and the installed `weread` bin as real child processes, and both are
+ * These suites drive `npm` and the installed `weread-omni` bin as real child processes, and both are
  * spelled differently on Windows:
  *
  * * `npm` is `npm.cmd`. Since the fix for CVE-2024-27980, Node refuses to run a `.cmd` through

--- a/test/unit/default-account.test.ts
+++ b/test/unit/default-account.test.ts
@@ -46,7 +46,7 @@ describe("write gate defaults", () => {
   });
 
   // Upload was opt-in only because enabling it made the MCP server demand S3 storage and refuse to
-  // start without it. With that server gone, `weread import book` uploads straight to WeRead, so
+  // start without it. With that server gone, `weread-omni import book` uploads straight to WeRead, so
   // it is an ordinary write like the rest.
   it("permits personal-book import by default", () => {
     expect(operationEnabled("import.book", {})).toBe(true);
@@ -92,7 +92,7 @@ describe("default account selection", () => {
     const manager = new AccountManager({ env: temporaryEnv("personal", "work") });
     expect(() => manager.select()).toThrow(AuthError);
     expect(() => manager.select()).toThrow(/personal, work/);
-    expect(() => manager.select()).toThrow(/weread accounts use <alias>/);
+    expect(() => manager.select()).toThrow(/weread-omni accounts use <alias>/);
   });
 
   it("uses the recorded default once one is set", () => {

--- a/test/unit/plugin-accounts.test.ts
+++ b/test/unit/plugin-accounts.test.ts
@@ -277,7 +277,7 @@ describe("client plugins and account storage", () => {
     const loginStatus = sink();
 
     await expect(
-      runAccountCli(["node", "weread", "--account", "work", "login", "--client", "mobile", "--json"], {
+      runAccountCli(["node", "weread-omni", "--account", "work", "login", "--client", "mobile", "--json"], {
         accountManager: manager,
         env,
         stdout: loginOut.stream,
@@ -290,7 +290,7 @@ describe("client plugins and account storage", () => {
 
     const commandOut = sink();
     await expect(
-      runAccountCli(["node", "weread", "book", "info", "book", "--json"], {
+      runAccountCli(["node", "weread-omni", "book", "info", "book", "--json"], {
         accountManager: manager,
         env,
         stdout: commandOut.stream,

--- a/test/unit/plugin-accounts.test.ts
+++ b/test/unit/plugin-accounts.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AccountManager } from "../../src/accounts.js";
 import type { CanonicalClient } from "../../src/api/client.js";
@@ -191,6 +192,85 @@ describe("client plugins and account storage", () => {
     await expect(new AccountManager({ env, plugins: [partial] }).open("work")).rejects.toThrow(
       /progress must be callable/,
     );
+  });
+
+  it("lets an interactive CLI choose one account from more than two configured accounts", async () => {
+    const env = temporaryEnv();
+    const callbacks = { client: "mobile", onQr: vi.fn(), onStatus: vi.fn(), onOtp: vi.fn() };
+    const manager = new AccountManager({ env, plugins: [plugin()] });
+    for (const alias of ["personal", "test", "work"]) {
+      await manager.login(alias, { ...callbacks, client: "mobile" });
+    }
+
+    const selected = vi.fn(async (accounts: readonly { account: string; client: string }[]) => {
+      expect(accounts.map(({ account }) => account)).toEqual(["personal", "test", "work"]);
+      return "test";
+    });
+    const commandOut = sink();
+    const commandErr = sink();
+
+    const code = await runAccountCli(["node", "weread-omni", "book", "info", "book", "--no-library"], {
+      accountManager: manager,
+      env,
+      stdout: commandOut.stream,
+      stderr: commandErr.stream,
+      isTTY: true,
+      selectAccount: selected,
+    });
+    expect({ code, stderr: commandErr.read() }).toEqual({ code: 0, stderr: "" });
+    expect(selected).toHaveBeenCalledOnce();
+    expect(commandOut.read()).toContain("book.info");
+
+    const nonInteractiveSelection = vi.fn(async () => "test");
+    const nonInteractiveErr = sink();
+    await expect(
+      runAccountCli(["node", "weread-omni", "book", "info", "book", "--json", "--no-library"], {
+        accountManager: manager,
+        env,
+        stderr: nonInteractiveErr.stream,
+        isTTY: false,
+        selectAccount: nonInteractiveSelection,
+      }),
+    ).resolves.toBe(1);
+    expect(nonInteractiveSelection).not.toHaveBeenCalled();
+    expect(nonInteractiveErr.read()).toContain("multiple WeRead accounts are configured");
+
+    const input = new PassThrough();
+    const stdin = vi.spyOn(process, "stdin", "get").mockReturnValue(input as unknown as typeof process.stdin);
+    const promptedOut = sink();
+    const promptedErr = sink();
+    try {
+      const prompted = runAccountCli(["node", "weread-omni", "book", "info", "book", "--no-library"], {
+        accountManager: manager,
+        env,
+        stdout: promptedOut.stream,
+        stderr: promptedErr.stream,
+        isTTY: true,
+      });
+      input.end("2\n");
+      await expect(prompted).resolves.toBe(0);
+    } finally {
+      stdin.mockRestore();
+    }
+    // `--json` declares the output machine-read, so it must refuse rather than ask -- even from a
+    // terminal, because a caller piping JSON onward still inherits that terminal's stdin.
+    const jsonSelection = vi.fn(async () => "test");
+    const jsonErr = sink();
+    await expect(
+      runAccountCli(["node", "weread-omni", "book", "info", "book", "--json", "--no-library"], {
+        accountManager: manager,
+        env,
+        stderr: jsonErr.stream,
+        isTTY: true,
+        selectAccount: jsonSelection,
+      }),
+    ).resolves.toBe(1);
+    expect(jsonSelection).not.toHaveBeenCalled();
+    expect(jsonErr.read()).toContain("multiple WeRead accounts are configured");
+
+    expect(promptedErr.read()).toContain("1. personal");
+    expect(promptedErr.read()).toContain("Select an account by number or alias:");
+    expect(promptedOut.read()).toContain("book.info");
   });
 
   it("accepts a client without chapter content and one that carries it as an extra", async () => {

--- a/test/unit/release.test.ts
+++ b/test/unit/release.test.ts
@@ -169,7 +169,7 @@ describe("release artifacts", () => {
     expect(await text("LICENSE")).toMatch(/MIT License[\s\S]*Permission is hereby granted/);
   });
 
-  it("records the complete first public release with no pending changes", async () => {
+  it("records every release, with no pending changes", async () => {
     const changelog = await text("CHANGELOG.md");
     const manifest = JSON.parse(await text("package.json")) as { version: string };
 
@@ -178,9 +178,12 @@ describe("release artifacts", () => {
     const current = changelog.indexOf(`## [${manifest.version}]`);
     expect(unreleased?.index).toBe(changelog.search(/^## \[/m));
     expect(unreleased?.[1]?.trim()).toBe("");
+    // The shipping version has to have its own section, immediately after Unreleased.
     expect(current).toBeGreaterThan(unreleased?.index ?? -1);
-    const next = changelog.indexOf("\n## [", current + 1);
-    const release = changelog.slice(current, next < 0 ? undefined : next);
+    // The initial release keeps describing the whole surface, whatever ships later.
+    const first = changelog.indexOf("## [0.1.0]");
+    const firstNext = changelog.indexOf("\n## [", first + 1);
+    const release = changelog.slice(first, firstNext < 0 ? undefined : firstNext);
     expect(release).toContain("MobileApiClient");
     expect(release).toContain("WEREAD_PLUGINS");
     expect(release).toContain("incremental deltas");

--- a/test/unit/release.test.ts
+++ b/test/unit/release.test.ts
@@ -31,7 +31,7 @@ describe("release artifacts", () => {
 
     expect(manifest.name).toBe("weread-omni");
     expect(manifest.engines.node).toBe(">=22.13.0");
-    expect(manifest.bin).toEqual({ weread: "./dist/cli.js" });
+    expect(manifest.bin).toEqual({ "weread-omni": "./dist/cli.js" });
     expect(manifest.files).toEqual([
       "dist",
       "docs",
@@ -112,7 +112,7 @@ describe("release artifacts", () => {
     }
     expect(readme).toContain("非官方");
     expect(readme).toContain("chapters(bookId)");
-    expect(readme).toContain("weread accounts");
+    expect(readme).toContain("weread-omni accounts");
     expect(readme).toContain("AccountManager");
     expect(readme).toContain("[更新日志](CHANGELOG.md)");
     expect(readme).toContain("[安全政策](SECURITY.md)");
@@ -123,7 +123,7 @@ describe("release artifacts", () => {
     }
     expect(english).toContain("unofficial");
     expect(english).toContain("chapters(bookId)");
-    expect(english).toContain("weread accounts");
+    expect(english).toContain("weread-omni accounts");
     expect(english).toContain("AccountManager");
     expect(english).toContain("[Changelog](CHANGELOG.md)");
     expect(english).toContain("[Security policy](SECURITY.md)");
@@ -133,6 +133,20 @@ describe("release artifacts", () => {
   // This checks only the second. The earlier version of this ban covered the two READMEs, which is
   // how SKILL.md and SECURITY.md kept naming the five removed write gates through three refactors --
   // SKILL.md being the file an agent actually reads at runtime.
+  // The CLI is `weread-omni`; the bundled skill is still `weread`. A rename sweep that cannot tell
+  // them apart produces an install command for a skill that does not exist -- which is exactly what
+  // happened, and what only a reader comparing two adjacent lines would have caught.
+  it("installs a skill that the repository actually ships", async () => {
+    for (const doc of ["README.md", "README.en.md"]) {
+      const referenced = [...(await text(doc)).matchAll(/--skill\s+(\S+)/g)].map(([, name]) => name);
+      expect(referenced.length, `${doc} documents no skill install`).toBeGreaterThan(0);
+      for (const name of referenced) {
+        const skill = await text(`skills/${name}/SKILL.md`);
+        expect(skill, `${doc} installs --skill ${name}`).toContain(`name: ${name}`);
+      }
+    }
+  });
+
   it("names no removed configuration in any shipped document", async () => {
     const removed = [
       "WEREAD_ALLOW_",
@@ -328,7 +342,7 @@ describe("release artifacts", () => {
     expect(packSmoke).toContain("node-version: 22.13.0");
     expect(packSmoke).toContain("npm install --engine-strict --ignore-scripts --no-audit --no-fund");
     expect(packSmoke).toContain('await Promise.all(["weread-omni", "weread-omni/cli"]');
-    expect(packSmoke).toContain("./node_modules/.bin/weread --help");
+    expect(packSmoke).toContain("./node_modules/.bin/weread-omni --help");
   });
 
   it("pins every external workflow action to a commit", async () => {

--- a/test/unit/release.test.ts
+++ b/test/unit/release.test.ts
@@ -498,7 +498,6 @@ describe("release artifacts", () => {
 
     const identity = workflow.indexOf("- name: Verify the retained package identity and digest");
     const tooling = workflow.indexOf("actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020");
-    const auth = workflow.indexOf("- name: Confirm registry authentication");
     const publish = workflow.indexOf("- name: Recheck the digest and publish the retained tarball");
     const sourceIdentity = workflow.indexOf('source.name !== "weread-omni"');
     // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting the literal workflow script
@@ -506,15 +505,14 @@ describe("release artifacts", () => {
     const canonicalTarball = workflow.indexOf("metadata.tarball !== expectedTarball");
     const resolveTarball = workflow.indexOf('resolve("candidate", expectedTarball)');
     const exportTarball = workflow.indexOf("appendFileSync(process.env.GITHUB_ENV");
-    expect([identity, tooling, auth, publish].every((index) => index >= 0)).toBe(true);
+    expect([identity, tooling, publish].every((index) => index >= 0)).toBe(true);
     expect(identity).toBeLessThan(sourceIdentity);
     expect(sourceIdentity).toBeLessThan(versionIdentity);
     expect(versionIdentity).toBeLessThan(canonicalTarball);
     expect(canonicalTarball).toBeLessThan(resolveTarball);
     expect(resolveTarball).toBeLessThan(exportTarball);
     expect(identity).toBeLessThan(tooling);
-    expect(tooling).toBeLessThan(auth);
-    expect(auth).toBeLessThan(publish);
+    expect(tooling).toBeLessThan(publish);
     expect(workflow.slice(publish)).toContain(
       'npm publish "$TARBALL" --provenance --access public --tag "$NPM_DIST_TAG"',
     );
@@ -559,12 +557,15 @@ describe("release artifacts", () => {
     // gate is a protected Environment holding the registry token.
     expect(workflow).toContain("environment: npm-publish");
 
-    // The registry token is exposed to the authentication and publish steps only.
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting the literal GitHub Actions secret expression
-    const authToken = "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}";
-    expect(workflow).toContain(authToken);
-    expect(countOccurrences(workflow, authToken)).toBe(2);
-    expect(countOccurrences(workflow, "NODE_AUTH_TOKEN")).toBe(2);
+    // Authentication is OIDC trusted publishing, so there must be no token fallback at
+    // all. A workflow that still carries one would silently keep working after the trust
+    // relationship was revoked, which is the failure this asserts away.
+    expect(workflow).not.toContain("NODE_AUTH_TOKEN");
+    expect(workflow).not.toContain("NPM_TOKEN");
+    expect(workflow).not.toContain("npm whoami");
+    // The credential npm exchanges the id-token for is scoped by these two.
+    expect(workflow).toContain("id-token: write");
+    expect(workflow).toContain("environment: npm-publish");
   });
 
   it("ships an explicit first-publish and Trusted Publishing runbook", async () => {


### PR DESCRIPTION
Stacked on #1 — retargets to `main` when that merges. The diff here is the single feature commit.

An interactive command with more than one configured account and no recorded default used to fail, telling you to pass `--account` or run `accounts use <alias>`. It now lists the accounts and asks.

## Asking is the last resort

Every condition must hold: no `--account`, **no `--json`**, more than one account, no recorded default, and a terminal to answer on.

`--json` disqualifies a caller **even from a terminal**. It declares the output machine-read — the same way this CLI already forces `--yes` on destructive commands — and a caller piping JSON onward still inherits the terminal's stdin. Without that check, `weread-omni … --json | jq` blocks on a question nobody sees. Such callers keep the old `pass --account` error.

## Two defects found in review, both fixed here

Codex reviewed this as part of a polish pass. Both were real, and I verified each by running the code rather than reasoning about it:

**EOF hung the CLI forever.** `readline.question()` never settles when stdin closes, so Ctrl-D or a closed pipe would hang with the interface still open — the `finally` that closes it never runs. Confirmed with a standalone repro before fixing. The interface's `close` event *does* fire, so an `AbortController` wired to it aborts the pending question, and that surfaces as `no account was selected`.

**`--json` was not in the gate.** The original code's own comment claimed "an agent driving `--json` keeps the old path" — a property the code did not have. The comment was right about the intent and wrong about the behaviour; the gate now matches the comment.

The existing test asserted that a `--json` invocation *does* prompt, which is exactly the behaviour being corrected. It's been changed to exercise prompting without `--json`, and a new case pins that `--json` refuses on a TTY instead of asking.

## Detail

- Accepts an alias or a list position, and matches a digit-only alias **as an alias** before reading it as a position
- Writes to stderr, so stdout stays a clean JSON channel
- An unrecognised answer is an `AuthError`, not a retry loop
- `selectAccount` on `AccountCliDependencies` overrides the prompt, which is how the tests drive it without a TTY

That last one adds one public export, `AccountSelector`, on `weread-omni/cli` — so the API-surface snapshot moves with this commit rather than being blessed silently elsewhere.

## Provenance

This arrived in the worktree while I was preparing the 0.1.1 release and my `git add -A` swept it into that commit. It's on its own branch now so it can be reviewed as a feature rather than as release noise. I did not write the original.

## Verification

`typecheck`, `lint`, **1048 tests**, **12 e2e**, coverage.