### PR TITLE
fix: settle the interactive prompts when stdin ends

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -308,14 +308,7 @@ export function createProgram<TClient extends CliOperationsClient = MobileApiCli
     });
   const confirm =
     dependencies.confirm ??
-    (async (message: string) => {
-      const prompt = createInterface({ input: process.stdin, output: process.stderr });
-      try {
-        return /^(?:y|yes)$/i.test((await prompt.question(`${message} [y/N] `)).trim());
-      } finally {
-        prompt.close();
-      }
-    });
+    (async (message: string) => /^(?:y|yes)$/i.test(await ask(`${message} [y/N] `, process.stderr)));
   const isTTY = dependencies.isTTY ?? process.stdin.isTTY === true;
   const program = new Command()
     .name("weread-omni")
@@ -475,12 +468,7 @@ export function createProgram<TClient extends CliOperationsClient = MobileApiCli
           },
           onOtp: async () => {
             if (!isTTY) throw new AuthError("this client requires a four-digit OTP from an interactive terminal");
-            const prompt = createInterface({ input: process.stdin, output: process.stderr });
-            try {
-              return (await prompt.question("Login OTP: ")).trim();
-            } finally {
-              prompt.close();
-            }
+            return ask("Login OTP: ", process.stderr);
           },
         });
         output(
@@ -763,40 +751,49 @@ export interface AccountCliDependencies extends Omit<CliDependencies, "accountMa
 
 export type AccountSelector = (accounts: readonly AccountSummary[]) => Promise<string> | string;
 
+/**
+ * Ask one question, and settle even when stdin ends without an answer.
+ *
+ * `readline/promises`' `question()` never settles if the stream reaches EOF first -- Ctrl-D, a
+ * closed pipe, a harness that inherits a terminal and then closes it. The `await` stays pending, so
+ * the caller's `finally` never runs and the interface stays open. The process does not hang
+ * visibly: the entry point consumes that promise with `.then()`, so the event loop simply drains and
+ * exits 0 having printed nothing, which a wrapper reads as "succeeded, empty result".
+ *
+ * The interface's `close` event does fire on EOF, so it aborts the pending question and the caller
+ * gets a rejection it can turn into an ordinary refusal.
+ */
+async function ask(query: string, output: NodeJS.WritableStream): Promise<string> {
+  const prompt = createInterface({ input: process.stdin, output, terminal: false });
+  const cancelled = new AbortController();
+  prompt.once("close", () => cancelled.abort());
+  try {
+    return (await prompt.question(query, { signal: cancelled.signal })).trim();
+  } catch (error) {
+    if (cancelled.signal.aborted) throw new AuthError("no answer was given");
+    throw error;
+  } finally {
+    prompt.close();
+  }
+}
+
 async function promptForAccount(accounts: readonly AccountSummary[], stderr: OutputWriter): Promise<string> {
   stderr.write("Multiple WeRead accounts are configured:\n");
   for (const [index, { account, client }] of accounts.entries()) {
     stderr.write(`  ${index + 1}. ${account} (${client})\n`);
   }
 
-  const prompt = createInterface({
-    input: process.stdin,
-    // readline writes the question to `output`, and never writes anything but a string there, so a
-    // one-method adapter is enough to keep the question on the same channel as the list above.
-    output: { write: (chunk: string) => stderr.write(chunk) } as NodeJS.WritableStream,
-    terminal: false,
-  });
-  // `question()` never settles when stdin reaches EOF -- Ctrl-D, or a closed pipe -- so without
-  // this the CLI would hang forever and the `finally` below would never run. `close` does fire, so
-  // it aborts the pending question and the catch turns that into an ordinary refusal.
-  const cancelled = new AbortController();
-  prompt.once("close", () => cancelled.abort());
-  try {
-    const answer = (
-      await prompt.question("Select an account by number or alias: ", { signal: cancelled.signal })
-    ).trim();
-    // An alias made of digits is still an alias; the list position is only the fallback reading.
-    const selected =
-      accounts.find(({ account }) => account === answer) ??
-      (/^\d+$/.test(answer) ? accounts[Number(answer) - 1] : undefined);
-    if (!selected) throw new AuthError(`unknown account selection ${JSON.stringify(answer)}`);
-    return selected.account;
-  } catch (error) {
-    if (cancelled.signal.aborted) throw new AuthError("no account was selected");
-    throw error;
-  } finally {
-    prompt.close();
-  }
+  // readline writes the question to `output` and never writes anything but a string there, so a
+  // one-method adapter keeps it on the same channel as the list above.
+  const answer = await ask("Select an account by number or alias: ", {
+    write: (chunk: string) => stderr.write(chunk),
+  } as NodeJS.WritableStream);
+  // An alias made of digits is still an alias; the list position is only the fallback reading.
+  const selected =
+    accounts.find(({ account }) => account === answer) ??
+    (/^\d+$/.test(answer) ? accounts[Number(answer) - 1] : undefined);
+  if (!selected) throw new AuthError(`unknown account selection ${JSON.stringify(answer)}`);
+  return selected.account;
 }
 
 export async function runAccountCli(


### PR DESCRIPTION
Stacked on #2. Fixes the same EOF defect in the two prompts that predate this stack and shipped in `0.1.0`.

## The bug does not look like a hang

`readline/promises`' `question()` never settles when the input stream reaches EOF without a line — Ctrl-D, a closed pipe, a harness that inherits a terminal and then closes it. The `await` stays pending, so the caller's `finally` never runs and the interface stays open.

What makes it worth fixing rather than tolerating is what happens next: the entry point consumes that promise with `.then()`, so nothing is waiting on it. The event loop drains and **the process exits 0 having printed nothing**.

```
weread-omni shelf delete b     # answer with Ctrl-D
→ exit 0, no output, book not deleted
```

A wrapper reads that as "succeeded, empty result". Credit to the reviewer that spotted the exit-0 consequence — I had it filed as a hang, which understates it.

## Three prompts, now one implementation

| Prompt | Status |
|---|---|
| `confirm` (`cli.ts:314`) | pre-existing, shipped in 0.1.0 |
| `onOtp` (`cli.ts:480`) | pre-existing, shipped in 0.1.0 |
| account selection | fixed in #2, folded in here |

Rather than leave three copies of the same subtlety, they now share `ask()`. It aborts the pending question from the interface's `close` event — which *does* fire on EOF — and turns that into `no answer was given`.

## Verified against the real binary, not reasoned about

I confirmed the defect with a standalone repro first (`question()` never settles, for both the `terminal: false` shape and the default-terminal shape), then confirmed the fix end to end:

```
EOF at the delete confirmation → exit 1, "Error: no answer was given"
```

Before: exit 0, silence.

## Test coverage, stated honestly

The two older prompts have **no regression test**. Reaching `onOtp` needs a live QR login, and `confirm` needs a destructive confirmation — the same harness difficulty that let the bug ship invisibly. The account prompt's existing tests exercise the shared `ask()`, so the logic is covered; the two call sites are not.

`typecheck`, `lint`, **1049 tests**, **12 e2e**, coverage.