### PR TITLE
docs: document the account prompt and the EOF fix under 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ CLI surface is **experimental** and may change in a minor release.
   reinstall; the old `weread` binary is not removed by upgrading.
 - Recovery hints name the new command, so a copied suggestion works as printed.
 
+### Added
+
+- **An interactive command asks which account to use** when several are
+  configured and none is recorded as the default, instead of failing with
+  "pass --account". It asks only when someone is there to answer: never with
+  `--json`, never without a terminal, so a script, a pipe, or an agent driving
+  the JSON CLI keeps the old error. `selectAccount` on `AccountCliDependencies`
+  overrides the prompt, and `AccountSelector` is exported from
+  `weread-omni/cli`.
+
+### Fixed
+
+- **The interactive prompts no longer exit silently when stdin ends.**
+  `readline`'s `question()` never settles at EOF, so Ctrl-D or a closed pipe
+  left the promise pending; nothing awaited it, the event loop drained, and the
+  process exited 0 having printed nothing. `weread-omni shelf delete` answered
+  with Ctrl-D reported success and deleted nothing. All three prompts -- the
+  delete confirmation, the login OTP, and the account chooser -- now report
+  "no answer was given" and exit non-zero.
+
 Credential and library locations are untouched: `~/.config/weread/` and
 `~/.local/share/weread/library` keep an existing login and cached content. The
 projected tool names, the upstream host, and the bundled skill are unchanged.


### PR DESCRIPTION
`0.1.1` shipped three changes, but the changelog entry documents one.

| Commit | In `## [0.1.1]`? |
| --- | --- |
| `712d347` rename the CLI command to `weread-omni` | yes |
| `5876aca` prompt for an account when several are configured | **no** |
| `673f00b` settle the interactive prompts when stdin ends | **no** |

The entry was written in the release commit, before #2 and #3 merged, and
neither PR updated it. The silent-exit fix in particular is worth stating
plainly: `weread-omni shelf delete` answered with Ctrl-D exited 0 and deleted
nothing.

This adds the missing `### Added` and `### Fixed` sections. Docs only — no
source change, and the `v0.1.1` tag is untouched.

The published `0.1.1` tarball keeps the incomplete changelog; that corrects
itself on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQHqpMCsN4t1khNE3hPUAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive account selector when multiple accounts are available in interactive CLI sessions.
  - Added safe handling for end-of-input during delete confirmations, login OTP entry, and account selection.

- **Bug Fixes**
  - Preserved existing account error behavior for JSON, non-terminal, and scripted commands.
  - Improved release publishing authentication through secure OIDC-based npm publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->